### PR TITLE
test: add self-hosted zero-config mode tests

### DIFF
--- a/tests/test_selfhosted_zero_config.py
+++ b/tests/test_selfhosted_zero_config.py
@@ -4,12 +4,14 @@ Tests for the zero-configuration self-hosted mode where users can run
 AxonFlow without any API keys, license keys, or credentials.
 
 This tests the scenario where a first-time user:
-1. Starts the agent with SELF_HOSTED_MODE=true and SELF_HOSTED_MODE_ACKNOWLEDGED=I_UNDERSTAND_NO_AUTH
+1. Starts the agent with SELF_HOSTED_MODE=true
+   and SELF_HOSTED_MODE_ACKNOWLEDGED=I_UNDERSTAND_NO_AUTH
 2. Connects the SDK with no credentials
 3. Makes requests that should succeed without authentication
 
 Run with:
-    AXONFLOW_AGENT_URL=http://localhost:8080 RUN_INTEGRATION_TESTS=1 pytest tests/test_selfhosted_zero_config.py -v
+    AXONFLOW_AGENT_URL=http://localhost:8080 \\
+    RUN_INTEGRATION_TESTS=1 pytest tests/test_selfhosted_zero_config.py -v
 """
 
 import os


### PR DESCRIPTION
## Summary

Add comprehensive tests for the zero-configuration self-hosted mode where users can run AxonFlow without any API keys, license keys, or credentials.

This tests the "first run" experience:
1. User starts the agent with `SELF_HOSTED_MODE=true` and `SELF_HOSTED_MODE_ACKNOWLEDGED=I_UNDERSTAND_NO_AUTH`
2. User connects the SDK with no credentials
3. SDK requests succeed without authentication errors

## Test Coverage

| Category | Tests |
|----------|-------|
| Client Initialization | 2 tests - empty/whitespace secrets for localhost |
| Gateway Mode | 3 tests - pre-check with empty/whitespace tokens, full flow |
| Proxy Mode | 1 test - execute_query with empty token |
| Policy Enforcement | 2 tests - SQL injection and PII still blocked |
| Health Check | 1 test - health check without credentials |
| First-Time User | 1 test - complete first-time user flow |

## How to Run

```bash
# Against local self-hosted agent
AXONFLOW_AGENT_URL=http://localhost:8080 RUN_INTEGRATION_TESTS=1 pytest tests/test_selfhosted_zero_config.py -v
```

## Related

- getaxonflow/axonflow-enterprise#682 - Issue: Zero-config self-hosted mode tests
- getaxonflow/axonflow-enterprise#683 - Agent-level tests (merged)