### PR TITLE
feat(map): add map_timeout config for longer MAP operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to the AxonFlow Python SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **MAP Timeout Configuration** - New `map_timeout` parameter (default: 120s) for Multi-Agent Planning operations
+  - MAP operations involve multiple LLM calls and can take 30-60+ seconds
+  - Separate `_map_http_client` with longer timeout
+  - `generate_plan()` and `execute_plan()` now use the longer MAP timeout
+
+## [0.3.0] - 2025-12-19
+
+### Added
+
+- **Gemini Interceptor** - Support for Google Generative AI models (#8)
+  - `wrap_gemini_model()` function for intercepting Gemini API calls
+  - Policy enforcement and audit logging for Gemini
+- Full feature parity with other SDKs for LLM interceptors
+
 ## [0.2.0] - 2025-12-15
 
 ### Added

--- a/axonflow/types.py
+++ b/axonflow/types.py
@@ -67,6 +67,7 @@ class AxonFlowConfig(BaseModel):
     mode: Mode = Field(default=Mode.PRODUCTION, description="Operation mode")
     debug: bool = Field(default=False, description="Enable debug logging")
     timeout: float = Field(default=60.0, gt=0, description="Request timeout (seconds)")
+    map_timeout: float = Field(default=120.0, gt=0, description="MAP operations timeout (seconds)")
     insecure_skip_verify: bool = Field(default=False, description="Skip TLS verify")
     retry: RetryConfig = Field(default_factory=RetryConfig)
     cache: CacheConfig = Field(default_factory=CacheConfig)


### PR DESCRIPTION
## Summary
- Add `map_timeout` parameter to AxonFlowConfig (default: 120s)
- Create separate `_map_http_client` with longer timeout for MAP operations
- Update `generate_plan()` and `execute_plan()` to use the longer MAP timeout

## Why
MAP (Multi-Agent Planning) operations involve multiple LLM calls and can take 30-60+ seconds. The default 60s timeout causes timeouts for complex queries.

## Test plan
- [x] All 203 unit tests pass
- [x] MAP example tested successfully against staging

## CHANGELOG
Updated with [Unreleased] section and added v0.3.0 entry for Gemini interceptor.