### PR TITLE
feat: add CodeArtifact type for code governance support

### DIFF
--- a/axonflow/__init__.py
+++ b/axonflow/__init__.py
@@ -80,7 +80,7 @@ from axonflow.types import (
     TokenUsage,
 )
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"
 __all__ = [
     # Main client
     "AxonFlow",

--- a/axonflow/types.py
+++ b/axonflow/types.py
@@ -97,7 +97,7 @@ class CodeArtifact(BaseModel):
     line_count: int = Field(default=0, ge=0, description="Number of lines of code")
     secrets_detected: int = Field(default=0, ge=0, description="Count of potential secrets found")
     unsafe_patterns: int = Field(default=0, ge=0, description="Count of unsafe code patterns")
-    policies_checked: list[str] = Field(default_factory=list, description="Code governance policies evaluated")
+    policies_checked: list[str] = Field(default_factory=list, description="Policies evaluated")
 
 
 class PolicyEvaluationInfo(BaseModel):
@@ -107,7 +107,7 @@ class PolicyEvaluationInfo(BaseModel):
     static_checks: list[str] = Field(default_factory=list)
     processing_time: str = Field(default="0ms")
     tenant_id: str = Field(default="")
-    code_artifact: CodeArtifact | None = Field(default=None, description="Code artifact metadata if code detected")
+    code_artifact: CodeArtifact | None = Field(default=None, description="Code metadata")
 
 
 class ClientResponse(BaseModel):


### PR DESCRIPTION
## Summary
- Add CodeArtifact model for LLM-generated code detection metadata
- Update PolicyEvaluationInfo to include optional code_artifact field
- Export CodeArtifact in __init__.py
- Bump version to 0.5.0

## Code Artifact Fields
- `is_code_output`: Whether response contains code
- `language`: Detected programming language
- `code_type`: Code category (function, class, script, etc.)
- `size_bytes`: Size of detected code in bytes
- `line_count`: Number of lines of code
- `secrets_detected`: Count of potential secrets found
- `unsafe_patterns`: Count of unsafe code patterns
- `policies_checked`: Code governance policies evaluated

## Test Plan
- [x] All existing tests pass
- [x] Tested locally against running server