### PR TITLE
fix: bump version to 0.5.0 for PyPI publish

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "axonflow"
-version = "0.4.0"
+version = "0.5.0"
 description = "AxonFlow Python SDK - Enterprise AI Governance in 3 Lines of Code"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
The v0.5.0 release failed to publish to PyPI because pyproject.toml version was still 0.4.0. This PR bumps the version so we can retrigger the release.