### PR TITLE
feat: add Code Governance Git Provider APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to the AxonFlow Python SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2025-12-29
+
+### Added
+
+- **Code Governance Git Provider APIs** (Enterprise): Create PRs from LLM-generated code
+  - `validate_git_provider()` - Validate credentials before saving
+  - `configure_git_provider()` - Configure GitHub, GitLab, or Bitbucket
+  - `list_git_providers()` - List configured providers
+  - `delete_git_provider()` - Remove a provider
+  - `create_pr()` - Create PR from generated code with audit trail
+  - `list_prs()` - List PRs with filtering
+  - `get_pr()` - Get PR details
+  - `sync_pr_status()` - Sync status from Git provider
+
+- **New Types**: `GitProviderType`, `FileAction`, `CodeFile`, `CreatePRRequest`, `CreatePRResponse`, `PRRecord`, `ListPRsOptions`, `ListPRsResponse`
+
+- **Supported Git Providers**:
+  - GitHub (Cloud and Enterprise Server)
+  - GitLab (Cloud and Self-Managed)
+  - Bitbucket (Cloud and Server/Data Center)
+
+---
+
 ## [0.5.0] - 2025-12-28
 
 ### Added

--- a/axonflow/__init__.py
+++ b/axonflow/__init__.py
@@ -26,6 +26,22 @@ Example:
 """
 
 from axonflow.client import AxonFlow, SyncAxonFlow
+from axonflow.code_governance import (
+    CodeFile,
+    ConfigureGitProviderRequest,
+    ConfigureGitProviderResponse,
+    CreatePRRequest,
+    CreatePRResponse,
+    FileAction,
+    GitProviderInfo,
+    GitProviderType,
+    ListGitProvidersResponse,
+    ListPRsOptions,
+    ListPRsResponse,
+    PRRecord,
+    ValidateGitProviderRequest,
+    ValidateGitProviderResponse,
+)
 from axonflow.exceptions import (
     AuthenticationError,
     AxonFlowError,
@@ -80,7 +96,7 @@ from axonflow.types import (
     TokenUsage,
 )
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 __all__ = [
     # Main client
     "AxonFlow",
@@ -129,6 +145,21 @@ __all__ = [
     "CreateDynamicPolicyRequest",
     "UpdateDynamicPolicyRequest",
     "CreatePolicyOverrideRequest",
+    # Code Governance types (Enterprise)
+    "GitProviderType",
+    "FileAction",
+    "CodeFile",
+    "ConfigureGitProviderRequest",
+    "ConfigureGitProviderResponse",
+    "ValidateGitProviderRequest",
+    "ValidateGitProviderResponse",
+    "GitProviderInfo",
+    "ListGitProvidersResponse",
+    "CreatePRRequest",
+    "CreatePRResponse",
+    "PRRecord",
+    "ListPRsOptions",
+    "ListPRsResponse",
     # Exceptions
     "AxonFlowError",
     "ConfigurationError",

--- a/axonflow/code_governance.py
+++ b/axonflow/code_governance.py
@@ -1,0 +1,164 @@
+"""Code Governance types for enterprise Git provider integration.
+
+This module provides types for:
+- Git provider configuration (GitHub, GitLab, Bitbucket)
+- Pull request creation from LLM-generated code
+- PR tracking and status synchronization
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class GitProviderType(str, Enum):
+    """Supported Git providers."""
+
+    GITHUB = "github"
+    GITLAB = "gitlab"
+    BITBUCKET = "bitbucket"
+
+
+class FileAction(str, Enum):
+    """File action for PR files."""
+
+    CREATE = "create"
+    UPDATE = "update"
+    DELETE = "delete"
+
+
+# ============================================================================
+# Git Provider Types
+# ============================================================================
+
+
+class ConfigureGitProviderRequest(BaseModel):
+    """Request to configure a Git provider."""
+
+    type: GitProviderType = Field(..., description="Provider type")
+    token: str | None = Field(default=None, description="Access token")
+    base_url: str | None = Field(default=None, description="Base URL for self-hosted")
+    app_id: int | None = Field(default=None, description="GitHub App ID")
+    installation_id: int | None = Field(default=None, description="GitHub App Installation ID")
+    private_key: str | None = Field(default=None, description="GitHub App private key (PEM)")
+
+
+class ValidateGitProviderRequest(BaseModel):
+    """Request to validate Git provider credentials."""
+
+    type: GitProviderType = Field(..., description="Provider type")
+    token: str | None = Field(default=None, description="Access token")
+    base_url: str | None = Field(default=None, description="Base URL for self-hosted")
+    app_id: int | None = Field(default=None, description="GitHub App ID")
+    installation_id: int | None = Field(default=None, description="GitHub App Installation ID")
+    private_key: str | None = Field(default=None, description="GitHub App private key (PEM)")
+
+
+class ValidateGitProviderResponse(BaseModel):
+    """Response from Git provider validation."""
+
+    valid: bool = Field(..., description="Whether credentials are valid")
+    message: str = Field(..., description="Validation message")
+
+
+class ConfigureGitProviderResponse(BaseModel):
+    """Response from Git provider configuration."""
+
+    message: str = Field(..., description="Success message")
+    type: str = Field(..., description="Configured provider type")
+
+
+class GitProviderInfo(BaseModel):
+    """Basic info about a configured provider."""
+
+    type: GitProviderType = Field(..., description="Provider type")
+
+
+class ListGitProvidersResponse(BaseModel):
+    """Response listing configured providers."""
+
+    providers: list[GitProviderInfo] = Field(default_factory=list)
+    count: int = Field(default=0)
+
+
+# ============================================================================
+# PR/MR Types
+# ============================================================================
+
+
+class CodeFile(BaseModel):
+    """A code file to include in a PR."""
+
+    path: str = Field(..., description="File path relative to repo root")
+    content: str = Field(..., description="File content")
+    language: str | None = Field(default=None, description="Programming language")
+    action: FileAction = Field(..., description="File action")
+
+
+class CreatePRRequest(BaseModel):
+    """Request to create a PR from LLM-generated code."""
+
+    owner: str = Field(..., description="Repository owner")
+    repo: str = Field(..., description="Repository name")
+    title: str = Field(..., description="PR title")
+    description: str | None = Field(default=None, description="PR description")
+    base_branch: str | None = Field(default=None, description="Base branch")
+    branch_name: str | None = Field(default=None, description="Head branch name")
+    draft: bool = Field(default=False, description="Create as draft")
+    files: list[CodeFile] = Field(..., description="Files to include")
+    agent_request_id: str | None = Field(
+        default=None, description="Agent request ID for traceability"
+    )
+    model: str | None = Field(default=None, description="LLM model used")
+    policies_checked: list[str] | None = Field(default=None, description="Policies checked")
+    secrets_detected: int | None = Field(default=None, description="Secrets detected count")
+    unsafe_patterns: int | None = Field(default=None, description="Unsafe patterns count")
+
+
+class CreatePRResponse(BaseModel):
+    """Response from PR creation."""
+
+    pr_id: str = Field(..., description="Internal PR record ID")
+    pr_number: int = Field(..., description="PR number on Git provider")
+    pr_url: str = Field(..., description="PR URL")
+    state: str = Field(..., description="PR state")
+    head_branch: str = Field(..., description="Head branch name")
+    created_at: datetime = Field(..., description="Creation timestamp")
+
+
+class PRRecord(BaseModel):
+    """A PR record in the system."""
+
+    id: str = Field(..., description="Internal PR record ID")
+    pr_number: int = Field(..., description="PR number on Git provider")
+    pr_url: str = Field(..., description="PR URL")
+    title: str = Field(..., description="PR title")
+    state: str = Field(..., description="PR state")
+    owner: str = Field(..., description="Repository owner")
+    repo: str = Field(..., description="Repository name")
+    head_branch: str = Field(..., description="Head branch")
+    base_branch: str = Field(..., description="Base branch")
+    files_count: int = Field(..., description="Number of files")
+    secrets_detected: int = Field(..., description="Secrets detected")
+    unsafe_patterns: int = Field(..., description="Unsafe patterns")
+    created_at: datetime = Field(..., description="Creation timestamp")
+    created_by: str | None = Field(default=None, description="Creator")
+    provider_type: str | None = Field(default=None, description="Provider type")
+
+
+class ListPRsOptions(BaseModel):
+    """Options for listing PRs."""
+
+    limit: int | None = Field(default=None, description="Max PRs to return")
+    offset: int | None = Field(default=None, description="Pagination offset")
+    state: str | None = Field(default=None, description="Filter by state")
+
+
+class ListPRsResponse(BaseModel):
+    """Response listing PRs."""
+
+    prs: list[PRRecord] = Field(default_factory=list, description="PR records")
+    count: int = Field(default=0, description="Total count")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "axonflow"
-version = "0.5.0"
+version = "0.6.0"
 description = "AxonFlow Python SDK - Enterprise AI Governance in 3 Lines of Code"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
- Add enterprise Code Governance APIs for Git provider integration
- Support GitHub, GitLab, and Bitbucket (cloud and self-hosted)
- Create PRs from LLM-generated code with audit trail

## New Methods
| Method | Description |
|--------|-------------|
| `validate_git_provider()` | Validate credentials before saving |
| `configure_git_provider()` | Configure GitHub, GitLab, or Bitbucket |
| `list_git_providers()` | List configured providers |
| `delete_git_provider()` | Remove a provider |
| `create_pr()` | Create PR from generated code |
| `list_prs()` | List PRs with filtering |
| `get_pr()` | Get PR details |
| `sync_pr_status()` | Sync status from Git provider |

## New Types
- `GitProviderType`, `FileAction`, `CodeFile`
- `ConfigureGitProviderRequest`, `ConfigureGitProviderResponse`
- `ValidateGitProviderRequest`, `ValidateGitProviderResponse`
- `CreatePRRequest`, `CreatePRResponse`, `PRRecord`
- `ListPRsOptions`, `ListPRsResponse`

## Test plan
- [ ] SDK imports work correctly
- [ ] Example in ee/examples/code-governance/python works