### PR TITLE
chore: add v0.9.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the AxonFlow Python SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2025-12-30
+
+### Fixed
+
+- Fixed `PolicyOverride` model field names (`action_override`, `override_reason`)
+- Fixed `list_policy_overrides()` endpoint path
+- Fixed `get_static_policy_versions()` response parsing
+- Fixed datetime serialization in `create_policy_override()`
+
+> **Note:** These changes affect Enterprise users only. Community users can skip this release.
+
+---
+
 ## [0.8.0] - 2025-12-29
 
 ### Added


### PR DESCRIPTION
Add changelog entry for v0.9.0 release (PolicyOverride fixes - Enterprise only).