### PR TITLE
fix: bump version to 0.9.0 for PyPI publish

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "axonflow"
-version = "0.8.0"
+version = "0.9.0"
 description = "AxonFlow Python SDK - Enterprise AI Governance in 3 Lines of Code"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Bump version from 0.8.0 to 0.9.0 to allow PyPI publish.