### PR TITLE
fix: update PyPI profile metadata and documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,10 +248,10 @@ mypy axonflow
 
 ## Documentation
 
-- [API Reference](https://docs.getaxonflow.com/sdk/python/api)
-- [Gateway Mode Guide](https://docs.getaxonflow.com/sdk/python/gateway-mode)
-- [Examples](https://github.com/getaxonflow/axonflow/tree/main/sdk/python/examples)
+- [Getting Started](https://docs.getaxonflow.com/sdk/python-getting-started)
+- [Gateway Mode Guide](https://docs.getaxonflow.com/sdk/gateway-mode)
+- [Examples](https://github.com/getaxonflow/axonflow/tree/main/examples)
 
 ## License
 
-Apache 2.0 - See [LICENSE](LICENSE) for details.
+MIT - See [LICENSE](LICENSE) for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ keywords = [
     "policy", "compliance", "enterprise", "mcp", "multi-agent"
 ]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
@@ -70,7 +70,7 @@ all = [
 
 [project.urls]
 Homepage = "https://getaxonflow.com"
-Documentation = "https://docs.getaxonflow.com/sdk/python"
+Documentation = "https://docs.getaxonflow.com/sdk/python-getting-started"
 Repository = "https://github.com/getaxonflow/axonflow-sdk-python"
 Changelog = "https://github.com/getaxonflow/axonflow-sdk-python/blob/main/CHANGELOG.md"
 Issues = "https://github.com/getaxonflow/axonflow-sdk-python/issues"


### PR DESCRIPTION
## Summary

- Change Development Status from Beta to Production/Stable
- Fix broken documentation links in pyproject.toml and README
- Correct license reference from Apache 2.0 to MIT in README
- Update Examples link to correct path

## Changes

**pyproject.toml:**
- `Development Status :: 4 - Beta` → `Development Status :: 5 - Production/Stable`
- `Documentation` URL: `sdk/python` → `sdk/python-getting-started`

**README.md:**
- API Reference → Getting Started (no API reference page exists)
- Gateway Mode Guide: `sdk/python/gateway-mode` → `sdk/gateway-mode`
- Examples: `sdk/python/examples` → `examples`
- License: Apache 2.0 → MIT (matches LICENSE file)

## Test plan

- [ ] Verify links work after merge
- [ ] Verify PyPI profile shows "Production/Stable" after v0.10.2 release