### PR TITLE
feat(gateway): add pre_check() method alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the AxonFlow Python SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Gateway Mode Alias**: Added `pre_check()` as alias for `get_policy_approved_context()` for SDK method parity with Go, TypeScript, and Java SDKs
+
+---
+
 ## [0.13.0] - 2026-01-04
 
 ### Added

--- a/axonflow/client.py
+++ b/axonflow/client.py
@@ -977,6 +977,43 @@ class AxonFlow:
             block_reason=response.get("block_reason"),
         )
 
+    async def pre_check(
+        self,
+        user_token: str,
+        query: str,
+        data_sources: list[str] | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> PolicyApprovalResult:
+        """Alias for get_policy_approved_context().
+
+        Perform policy pre-check before making LLM call.
+        This is the first step in Gateway Mode.
+
+        Args:
+            user_token: JWT token for the user making the request
+            query: The query/prompt that will be sent to the LLM
+            data_sources: Optional list of MCP connectors to fetch data from
+            context: Optional additional context for policy evaluation
+
+        Returns:
+            PolicyApprovalResult with context ID and approved data
+
+        Example:
+            >>> result = await client.pre_check(
+            ...     user_token="user-jwt",
+            ...     query="Find patients with diabetes",
+            ...     data_sources=["postgres"]
+            ... )
+            >>> if not result.approved:
+            ...     raise PolicyViolationError(result.block_reason)
+        """
+        return await self.get_policy_approved_context(
+            user_token=user_token,
+            query=query,
+            data_sources=data_sources,
+            context=context,
+        )
+
     async def audit_llm_call(
         self,
         context_id: str,
@@ -2659,6 +2696,21 @@ class SyncAxonFlow:
         """Perform policy pre-check before making LLM call."""
         return self._run_sync(
             self._async_client.get_policy_approved_context(user_token, query, data_sources, context)
+        )
+
+    def pre_check(
+        self,
+        user_token: str,
+        query: str,
+        data_sources: list[str] | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> PolicyApprovalResult:
+        """Alias for get_policy_approved_context().
+
+        Perform policy pre-check before making LLM call.
+        """
+        return self._run_sync(
+            self._async_client.pre_check(user_token, query, data_sources, context)
         )
 
     def audit_llm_call(

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -302,3 +302,64 @@ class TestSyncGatewayMode:
         )
 
         assert result.success is True
+
+
+class TestPreCheckAlias:
+    """Test pre_check() alias method."""
+
+    @pytest.mark.asyncio
+    async def test_pre_check_alias_async(
+        self,
+        client: AxonFlow,
+        httpx_mock: HTTPXMock,
+        mock_pre_check_response: dict[str, Any],
+    ) -> None:
+        """Test async pre_check() is an alias for get_policy_approved_context()."""
+        httpx_mock.add_response(json=mock_pre_check_response)
+
+        result = await client.pre_check(
+            user_token="user-jwt",
+            query="Test query",
+            data_sources=["postgres"],
+        )
+
+        assert result.approved is True
+        assert result.context_id == "ctx-123"
+        assert "hipaa" in result.policies
+
+    @pytest.mark.asyncio
+    async def test_pre_check_alias_with_context(
+        self,
+        client: AxonFlow,
+        httpx_mock: HTTPXMock,
+        mock_pre_check_response: dict[str, Any],
+    ) -> None:
+        """Test pre_check() with context parameter."""
+        httpx_mock.add_response(json=mock_pre_check_response)
+
+        result = await client.pre_check(
+            user_token="user-jwt",
+            query="Test query",
+            context={"department": "engineering"},
+        )
+
+        assert result.approved is True
+        request = httpx_mock.get_request()
+        assert "/api/policy/pre-check" in str(request.url)
+
+    def test_pre_check_alias_sync(
+        self,
+        sync_client,
+        httpx_mock: HTTPXMock,
+        mock_pre_check_response: dict[str, Any],
+    ) -> None:
+        """Test sync pre_check() is an alias for get_policy_approved_context()."""
+        httpx_mock.add_response(json=mock_pre_check_response)
+
+        result = sync_client.pre_check(
+            user_token="user-jwt",
+            query="Test query",
+        )
+
+        assert result.approved is True
+        assert result.context_id == "ctx-123"


### PR DESCRIPTION
## Summary

Add `pre_check()` as an alias for `get_policy_approved_context()` to match the naming convention used in Go, TypeScript, and Java SDKs.

## Changes

- Added `pre_check()` method to async client
- Added `pre_check()` method to sync client
- Added tests for the alias

## Why

This achieves full SDK method parity across all 4 SDKs (66 methods). The `pre_check()` method name is consistent with other SDKs:
- Go: `PreCheck()`
- TypeScript: `preCheck()`
- Java: `preCheck()`

## Test Plan

- [x] Unit tests added (`tests/test_gateway.py::TestPreCheckAlias`)
- [x] All 3 tests pass locally