### PR TITLE
chore: bump version to 1.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "axonflow"
-version = "1.3.0"
+version = "1.4.0"
 description = "AxonFlow Python SDK - Enterprise AI Governance in 3 Lines of Code"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Bump pyproject.toml version to 1.4.0 to match CHANGELOG for release.

## Changes
- pyproject.toml: 1.3.0 → 1.4.0

## Release Notes
See CHANGELOG.md for v1.4.0 changes (MCP exfiltration detection and dynamic policies).