### PR TITLE
feat: Workflow Policy Enforcement (Issues #1019, #1020, #1021)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Helper methods on `WorkflowStatus` and `WorkflowStatusResponse`: `is_terminal()`
   - LangGraph adapter: `axonflow.adapters.langgraph.AxonFlowLangGraphAdapter`
 
+- **Workflow Policy Enforcement** (Issues #1019, #1020, #1021): Policy transparency for workflow operations
+  - `StepGateResponse` now includes `policies_evaluated` and `policies_matched` fields with `PolicyMatch` type
+  - `PolicyMatch` class with `policy_id`, `policy_name`, `action`, `reason` for policy transparency
+  - `PolicyEvaluationResult` class for MAP execution with `allowed`, `applied_policies`, `risk_score`
+  - Workflow operations (`workflow_created`, `workflow_step_gate`, `workflow_completed`) logged to audit trail
+
 ### Fixed
 
 - Datetime parsing now handles variable-length fractional seconds (e.g., 5 digits) for Python 3.9 compatibility

--- a/axonflow/__init__.py
+++ b/axonflow/__init__.py
@@ -114,6 +114,7 @@ from axonflow.types import (
     PlanStep,
     PolicyApprovalResult,
     PolicyEvaluationInfo,
+    PolicyEvaluationResult,
     PricingInfo,
     PricingListResponse,
     RateLimitInfo,
@@ -168,6 +169,7 @@ __all__ = [
     "PlanStep",
     "PlanResponse",
     "PlanExecutionResponse",
+    "PolicyEvaluationResult",
     # Gateway Mode types
     "RateLimitInfo",
     "PolicyApprovalResult",

--- a/axonflow/types.py
+++ b/axonflow/types.py
@@ -285,6 +285,31 @@ class PlanResponse(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 
+class PolicyEvaluationResult(BaseModel):
+    """Result of policy evaluation for workflow steps and plan executions.
+
+    Used by MAP (Multi-Agent Planning) and WCP (Workflow Control Plane) to provide
+    detailed policy enforcement information (Issues #1019, #1020, #1021).
+    """
+
+    allowed: bool = Field(..., description="Whether the action is allowed by policy")
+    applied_policies: list[str] = Field(
+        default_factory=list, description="List of policy IDs that were applied"
+    )
+    risk_score: float = Field(
+        default=0.0, ge=0.0, le=1.0, description="Calculated risk score (0.0-1.0)"
+    )
+    required_actions: list[str] | None = Field(
+        default=None, description="Actions required before proceeding (if any)"
+    )
+    processing_time_ms: int = Field(
+        default=0, ge=0, description="Time taken for policy evaluation in milliseconds"
+    )
+    database_accessed: bool | None = Field(
+        default=None, description="Whether a database was accessed during the operation"
+    )
+
+
 class PlanExecutionResponse(BaseModel):
     """Plan execution result."""
 
@@ -294,6 +319,9 @@ class PlanExecutionResponse(BaseModel):
     step_results: dict[str, Any] = Field(default_factory=dict)
     error: str | None = None
     duration: str | None = None
+    policy_info: PolicyEvaluationResult | None = Field(
+        default=None, description="Policy evaluation result for the plan execution"
+    )
 
 
 # Gateway Mode Types

--- a/axonflow/workflow.py
+++ b/axonflow/workflow.py
@@ -123,6 +123,14 @@ class StepGateResponse(BaseModel):
     approval_url: str | None = Field(
         default=None, description="URL to the approval portal (if decision is require_approval)"
     )
+    policies_evaluated: list[PolicyMatch] | None = Field(
+        default=None,
+        description="List of all policies that were evaluated during the gate check (Issue #1019)",
+    )
+    policies_matched: list[PolicyMatch] | None = Field(
+        default=None,
+        description="List of policies that matched and influenced the decision (Issue #1019)",
+    )
 
     def is_allowed(self) -> bool:
         """Check if the step is allowed to proceed."""


### PR DESCRIPTION
## Summary

- Adds `policies_evaluated` and `policies_matched` fields to `StepGateResponse` for policy transparency
- Adds `PolicyMatch` class with `policy_id`, `policy_name`, `action`, `reason` fields
- Adds `PolicyEvaluationResult` class for MAP execution with `allowed`, `applied_policies`, `risk_score`
- Updates CHANGELOG with Issues #1019, #1020, #1021

## Related

- Enterprise: getaxonflow/axonflow-enterprise#1023
- Docs: getaxonflow/axonflow-docs#191
- Issue #1019: Workflow Policy Enforcement
- Issue #1020: MAP Audit Logging
- Issue #1021: WCP Policy Transparency

## Test plan

- [ ] Existing tests pass
- [ ] Types validate with Pydantic
- [ ] Exports available in package