### PR TITLE
fix: bump version to 1.6.0 for PyPI release

### DIFF
--- a/axonflow/__init__.py
+++ b/axonflow/__init__.py
@@ -147,7 +147,7 @@ from axonflow.workflow import (
     WorkflowStepInfo,
 )
 
-__version__ = "1.2.0"
+__version__ = "1.6.0"
 __all__ = [
     # Main client
     "AxonFlow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "axonflow"
-version = "1.5.0"
+version = "1.6.0"
 description = "AxonFlow Python SDK - Enterprise AI Governance in 3 Lines of Code"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Fixes version mismatch that caused PyPI release failure.

- pyproject.toml: 1.5.0 → 1.6.0
- __init__.py: 1.2.0 → 1.6.0 (was out of sync)