### PR TITLE
chore: bump version to 1.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "axonflow"
-version = "1.6.0"
+version = "1.7.0"
 description = "AxonFlow Python SDK - Enterprise AI Governance in 3 Lines of Code"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Fixes version mismatch - pyproject.toml was 1.6.0 but CHANGELOG has 1.7.0 entry for 2026-01-24.