### PR TITLE
docs: add BudgetInfo to v1.7.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the AxonFlow Python SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.7.0] - 2026-01-24
+## [1.7.0] - 2026-01-25
 
 ### Added
 
@@ -37,10 +37,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Documents when to use Proxy Mode vs Gateway Mode
   - Same functionality as execute_query, but with clearer naming
 
+- **BudgetInfo**: `QueryResponse.budget_info` for budget enforcement (HTTP 402)
+
 ### Deprecated
 
 - **execute_query()**: Deprecated in favor of proxy_llm_call()
-  - Will be removed in v2.0.0
+  - Will be removed in v3.0.0
   - Emits deprecation warning in debug mode
   - Remains functional as a wrapper around proxy_llm_call()
 


### PR DESCRIPTION
## Summary
- Add budget_info field documentation for budget enforcement (HTTP 402)
- Update version date to 2026-01-25
- Fix deprecation version to v3.0.0 (version jump planned)

Part of Issue #1082 - Platform Features Wiring Audit