### PR TITLE
docs: add anonymous feedback form link to Support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,11 @@ For enterprise features, contact [sales@getaxonflow.com](mailto:sales@getaxonflo
 - **Issues**: https://github.com/getaxonflow/axonflow-sdk-python/issues
 - **Email**: dev@getaxonflow.com
 
+If you are evaluating AxonFlow in a company setting and cannot open a public issue, you can share feedback or blockers confidentially here:
+[Anonymous evaluation feedback form](https://getaxonflow.com/feedback)
+
+No email required. Optional contact if you want a response.
+
 ## License
 
 MIT - See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
Added anonymous evaluation feedback form link to the Support section for evaluators who cannot open public issues.

## Changes
Added to README.md Support section:
- Link to anonymous feedback form at https://getaxonflow.com/feedback
- Note that no email is required