### PR TITLE
fix(policies): add pii-singapore category to PolicyCategory enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BudgetInfo**: `QueryResponse.budget_info` for budget enforcement (HTTP 402)
 
+### Fixed
+
+- **PolicyCategory**: Added `PII_SINGAPORE = "pii-singapore"` enum value for MAS FEAT Singapore PII detection patterns
+
 ### Deprecated
 
 - **execute_query()**: Deprecated in favor of proxy_llm_call()

--- a/axonflow/policies.py
+++ b/axonflow/policies.py
@@ -28,6 +28,7 @@ class PolicyCategory(str, Enum):
     PII_US = "pii-us"
     PII_EU = "pii-eu"
     PII_INDIA = "pii-india"
+    PII_SINGAPORE = "pii-singapore"
 
     # Static policy categories - Code Governance
     CODE_SECRETS = "code-secrets"


### PR DESCRIPTION
## Summary

Add `PII_SINGAPORE = "pii-singapore"` to the `PolicyCategory` enum.

## Problem

The Python SDK was missing the `pii-singapore` category in its `PolicyCategory` enum, causing Pydantic validation errors when processing Singapore PII policies from the platform:

```
Input should be 'security-sqli', 'security-admin', 'pii-global', 'pii-us', 'pii-eu', 'pii-india', ...
[type=enum, input_value='pii-singapore', input_type=str]
```

## Fix

Added `PII_SINGAPORE = "pii-singapore"` to the `PolicyCategory` enum in `axonflow/policies.py`.

## Testing

- Verified `static-policies/python` example now passes all tests
- No breaking changes - additive enum value only