### PR TITLE
chore: bump version to 1.7.1 for pii-singapore fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the AxonFlow Python SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.1] - 2026-01-25
+
+### Fixed
+
+- **PolicyCategory**: Added `PII_SINGAPORE = "pii-singapore"` enum value for Singapore PII detection policies (NRIC, FIN, UEN patterns)
+
+---
+
 ## [1.7.0] - 2026-01-25
 
 ### Added
@@ -38,10 +46,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Same functionality as execute_query, but with clearer naming
 
 - **BudgetInfo**: `QueryResponse.budget_info` for budget enforcement (HTTP 402)
-
-### Fixed
-
-- **PolicyCategory**: Added `PII_SINGAPORE = "pii-singapore"` enum value for MAS FEAT Singapore PII detection patterns
 
 ### Deprecated
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "axonflow"
-version = "1.7.0"
+version = "1.7.1"
 description = "AxonFlow Python SDK - Enterprise AI Governance in 3 Lines of Code"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

Bump version to v1.7.1 for the pii-singapore PolicyCategory fix.

## Background

The actual code fix (`PII_SINGAPORE = "pii-singapore"` enum value) was merged in PR #70.

## Changes

- Updated `pyproject.toml` version from 1.7.0 to 1.7.1
- Moved the pii-singapore fix from v1.7.0 changelog to a new v1.7.1 section

## Release: v1.7.1

This is a patch release to properly version the pii-singapore fix.