### PR TITLE
chore: ignore codex and claude artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,5 @@ WEEK_[0-9]*.md
 *_PLAN.md
 *_SUMMARY.md
 *_COMPLETE.md
+
+.codex/


### PR DESCRIPTION
Add .codex/ and .claude/ to .gitignore to keep local assistant artifacts out of git.