### PR TITLE
fix: add workflow permissions to CI, integration, and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,6 +12,9 @@ on:
         required: false
         default: 'https://staging-eu.getaxonflow.com'
 
+permissions:
+  contents: read
+
 env:
   # Note: github.event.inputs only available on workflow_dispatch, defaults used otherwise
   AXONFLOW_AGENT_URL: ${{ github.event.inputs.agent_url || 'https://staging-eu.getaxonflow.com' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `permissions: contents: read` to `ci.yml`, `integration.yml`, and `release.yml` workflows
- Release workflow already had job-level permissions for `publish-pypi` and `create-release` — top-level default now restricts the `build` job

## CodeQL Alerts Resolved

- **8 MEDIUM** `actions/missing-workflow-permissions` across 3 workflow files

## Test plan

- [x] Python SDK imports successfully
- [ ] CI pipeline