### PR TITLE
chore: fix changelog date to 2026-02-12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the AxonFlow Python SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.3.1] - 2026-02-11
+## [3.3.1] - 2026-02-12
 
 ### Fixed
 


### PR DESCRIPTION
Fix v3.3.1 changelog date from 2026-02-11 to 2026-02-12 (released after midnight).