### PR TITLE
docs: update feedback link block

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Enterprise AI Governance in 3 Lines of Code.
 >
 > No commitment required. We reply within 48 hours.
 
-> **AxonFlow Feedback Week (Feb 5–12, 2026)** — We're shipping 3 improvements from user feedback.
+> **Questions or feedback?**
 >
-> [Share feedback](https://github.com/getaxonflow/axonflow/discussions/239) or email [hello@getaxonflow.com](mailto:hello@getaxonflow.com) for private feedback.
+> Comment in [GitHub Discussions](https://github.com/getaxonflow/axonflow/discussions/239) or email [hello@getaxonflow.com](mailto:hello@getaxonflow.com) for private feedback.
 
 ## How This SDK Fits with AxonFlow
 


### PR DESCRIPTION
Replaces the expired Feedback Week banner in README with an evergreen feedback link to GitHub Discussions plus hello@getaxonflow.com.