### PR TITLE
fix: bump version to 3.5.0 and add release verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Update version in source
+        run: |
+          VERSION=${{ steps.version.outputs.VERSION }}
+          sed -i "s/^version = .*/version = \"${VERSION}\"/" pyproject.toml
+          sed -i "s/^__version__ = .*/__version__ = \"${VERSION}\"/" axonflow/__init__.py
+          echo "Updated version to ${VERSION}"
+          grep version pyproject.toml | head -1
+          grep __version__ axonflow/__init__.py
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -87,3 +100,29 @@ jobs:
 
             See [CHANGELOG.md](https://github.com/getaxonflow/axonflow-sdk-python/blob/main/CHANGELOG.md) for full release details.
           generate_release_notes: false
+
+  verify-publish:
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Wait for PyPI propagation
+        run: sleep 30
+
+      - name: Verify package on PyPI
+        run: |
+          VERSION=${{ steps.version.outputs.VERSION }}
+          for i in 1 2 3 4 5; do
+            echo "Attempt $i: Checking PyPI for axonflow==${VERSION}..."
+            if pip install --dry-run axonflow==${VERSION} 2>&1 | grep -q "Would install"; then
+              echo "SUCCESS: axonflow ${VERSION} is available on PyPI"
+              exit 0
+            fi
+            echo "Not yet available, waiting 30 seconds..."
+            sleep 30
+          done
+          echo "FAILURE: axonflow ${VERSION} not found on PyPI after 5 attempts"
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the AxonFlow Python SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.5.0] - 2026-02-18
+## [3.5.0] - 2026-02-19
 
 ### Added
 

--- a/axonflow/__init__.py
+++ b/axonflow/__init__.py
@@ -202,7 +202,7 @@ from axonflow.workflow import (
     WorkflowStepInfo,
 )
 
-__version__ = "3.4.0"
+__version__ = "3.5.0"
 __all__ = [
     # Main client
     "AxonFlow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "axonflow"
-version = "3.4.0"
+version = "3.5.0"
 description = "AxonFlow Python SDK - Enterprise AI Governance in 3 Lines of Code"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
- Bumps version from 3.4.0 to 3.5.0 in `pyproject.toml` and `axonflow/__init__.py`
- Adds version extraction from git tag in release workflow (mirrors Java SDK approach)
- Adds post-publish PyPI verification step to catch failed publishes

## Context
The v3.5.0 release failed because the in-code version was still 3.4.0 when the tag was pushed. The release workflow built `axonflow-3.4.0` and PyPI rejected it (already exists). This PR fixes the version AND adds safeguards to prevent this from happening again.

## After merge
1. Delete existing v3.5.0 tag and GitHub release
2. Re-tag v3.5.0 at new main HEAD
3. Push tag to trigger fresh release workflow