### PR TITLE
fix(mcp): change mcp_check_input default operation from query to execute

### DIFF
--- a/axonflow/client.py
+++ b/axonflow/client.py
@@ -1082,7 +1082,7 @@ class AxonFlow:
         self,
         connector_type: str,
         statement: str,
-        operation: str = "query",
+        operation: str = "execute",
         parameters: dict[str, Any] | None = None,
     ) -> MCPCheckInputResponse:
         """Validate an MCP request against configured policies without executing it.
@@ -1093,7 +1093,7 @@ class AxonFlow:
         Args:
             connector_type: Type of MCP connector (e.g., "postgres", "snowflake").
             statement: The SQL query or command to validate.
-            operation: Operation type - "query" (default) or "execute".
+            operation: Operation type - "query" or "execute" (default).
             parameters: Optional query parameters.
 
         Returns:
@@ -5953,7 +5953,7 @@ class SyncAxonFlow:
         self,
         connector_type: str,
         statement: str,
-        operation: str = "query",
+        operation: str = "execute",
         parameters: dict[str, Any] | None = None,
     ) -> MCPCheckInputResponse:
         """Validate an MCP request against configured policies without executing it."""

--- a/axonflow/types.py
+++ b/axonflow/types.py
@@ -364,7 +364,7 @@ class MCPCheckInputRequest(BaseModel):
     connector_type: str
     statement: str
     parameters: dict[str, Any] | None = Field(default=None)
-    operation: str = Field(default="query")
+    operation: str = Field(default="execute")
 
 
 class MCPCheckInputResponse(BaseModel):


### PR DESCRIPTION
## Summary

- Changes the default value of the `operation` parameter in `mcp_check_input` (both async and sync) from `"query"` to `"execute"`
- Updates the `MCPCheckInputRequest` Pydantic model field default to match
- Updates the docstring to reflect the new default

## Context

Follow-up to getaxonflow/axonflow-enterprise#1288. The `check-input` endpoint is called by external orchestrators managing their own MCP execution — defaulting to `"execute"` (conservative, may have side effects) is semantically correct for a pre-flight gate, as opposed to `"query"` (implies read-only).