### PR TITLE
chore: remove Scarf tracking pixel from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,5 +427,3 @@ See [Telemetry Documentation](https://docs.getaxonflow.com/docs/telemetry) for f
 ## License
 
 MIT - See [LICENSE](LICENSE) for details.
-
-<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=fbda6e64-1812-428b-b135-ed2b548ce50d" />


### PR DESCRIPTION
## Summary

- Remove Scarf tracking pixel from Python SDK README
- GitHub's camo proxy strips viewer identity, making >50% of pixel views unattributable (attributed to "GitHub" instead of the actual company)

Pixel tracking for the docs site is being moved to a site-wide Docusaurus plugin (separate PR on axonflow-docs) where it works without GitHub's camo interference.