### PR TITLE
feat(client): add demo mode via AXONFLOW_DEMO env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ All notable changes to the AxonFlow Python SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [6.3.0] - Release Pending (2026-04-09)
+## [6.3.0] - Unreleased
 
 ### Added
-
+- `AXONFLOW_TRY=1` environment variable to connect to `try.getaxonflow.com` shared evaluation server
+- `register_try()` helper in `axonflow.community` for self-registering a tenant
+- Checkpoint telemetry reports `endpoint_type: "community-saas"` when try mode is active
 - **Explicit IPv6 + RFC1918 boundary test coverage.** The v6.2.0 test suite relied on Python stdlib `ipaddress.is_private` for correctness and didn't assert the behavior explicitly. New cases cover:
   - `172.15.0.1` and `172.32.0.1` must be `remote` (RFC1918 boundary)
   - `172.16.0.0` and `172.31.255.255` must be `private_network`
@@ -17,7 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Public IPv6 (`2001:4860:4860::8888`, `2606:4700:4700::1111`) → `remote`
   - IPv6 loopback `::1` → `localhost`
 
-No runtime behavior change — Python's stdlib classifier was already correct for all these cases. The added tests are cross-SDK parity with TS/Java/Go.
+No runtime behavior change for the IPv6 cases — Python's stdlib classifier was already correct for all these cases. The added tests are cross-SDK parity with TS/Java/Go.
+
+### Changed
+- Renamed `AXONFLOW_DEMO` to `AXONFLOW_TRY` (demo mode → try mode)
+- Removed client-side random suffix from client_id (server generates UUID tenant_id)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the AxonFlow Python SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [6.3.0] - Unreleased
+## [6.3.0] - 2026-04-09
 
 ### Added
 - `AXONFLOW_TRY=1` environment variable to connect to `try.getaxonflow.com` shared evaluation server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,19 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AXONFLOW_TRY=1` environment variable to connect to `try.getaxonflow.com` shared evaluation server
 - `register_try()` helper in `axonflow.community` for self-registering a tenant
 - Checkpoint telemetry reports `endpoint_type: "community-saas"` when try mode is active
-- **Explicit IPv6 + RFC1918 boundary test coverage.** The v6.2.0 test suite relied on Python stdlib `ipaddress.is_private` for correctness and didn't assert the behavior explicitly. New cases cover:
-  - `172.15.0.1` and `172.32.0.1` must be `remote` (RFC1918 boundary)
-  - `172.16.0.0` and `172.31.255.255` must be `private_network`
-  - IPv6 ULA (`fd00::1`, `fd12:3456:789a::1`, `fc00::1`) → `private_network`
-  - IPv6 link-local (`fe80::1`) → `private_network`
-  - Public IPv6 (`2001:4860:4860::8888`, `2606:4700:4700::1111`) → `remote`
-  - IPv6 loopback `::1` → `localhost`
-
-No runtime behavior change for the IPv6 cases — Python's stdlib classifier was already correct for all these cases. The added tests are cross-SDK parity with TS/Java/Go.
-
-### Changed
-- Renamed `AXONFLOW_DEMO` to `AXONFLOW_TRY` (demo mode → try mode)
-- Removed client-side random suffix from client_id (server generates UUID tenant_id)
 
 ---
 

--- a/axonflow/client.py
+++ b/axonflow/client.py
@@ -364,6 +364,12 @@ class AxonFlow:
             msg = "endpoint is required (or set AXONFLOW_AGENT_URL environment variable)"
             raise TypeError(msg)
 
+        if os.environ.get("AXONFLOW_DEMO") == "1":
+            resolved_endpoint = "https://demo.getaxonflow.com"
+            if not client_id:
+                msg = "client_id is required in demo mode (AXONFLOW_DEMO=1)"
+                raise TypeError(msg)
+
         if isinstance(mode, str):
             mode = Mode(mode)
 

--- a/axonflow/client.py
+++ b/axonflow/client.py
@@ -358,16 +358,17 @@ class AxonFlow:
 
             As of v1.0.0, all routes go through a single endpoint (Single Entry Point Architecture).
         """
-        # Support AXONFLOW_AGENT_URL env var for backwards compatibility
-        resolved_endpoint = endpoint or os.environ.get("AXONFLOW_AGENT_URL")
-        if not resolved_endpoint:
-            msg = "endpoint is required (or set AXONFLOW_AGENT_URL environment variable)"
-            raise TypeError(msg)
-
+        # Try mode: auto-connect to try.getaxonflow.com (must be checked before endpoint validation)
         if os.environ.get("AXONFLOW_TRY") == "1":
             resolved_endpoint = "https://try.getaxonflow.com"
             if not client_id:
                 msg = "client_id is required in try mode (AXONFLOW_TRY=1)"
+                raise TypeError(msg)
+        else:
+            # Support AXONFLOW_AGENT_URL env var for backwards compatibility
+            resolved_endpoint = endpoint or os.environ.get("AXONFLOW_AGENT_URL")
+            if not resolved_endpoint:
+                msg = "endpoint is required (or set AXONFLOW_AGENT_URL environment variable)"
                 raise TypeError(msg)
 
         if isinstance(mode, str):

--- a/axonflow/client.py
+++ b/axonflow/client.py
@@ -366,7 +366,7 @@ class AxonFlow:
                 raise TypeError(msg)
         else:
             # Support AXONFLOW_AGENT_URL env var for backwards compatibility
-            resolved_endpoint = endpoint or os.environ.get("AXONFLOW_AGENT_URL")
+            resolved_endpoint = endpoint or os.environ.get("AXONFLOW_AGENT_URL") or ""
             if not resolved_endpoint:
                 msg = "endpoint is required (or set AXONFLOW_AGENT_URL environment variable)"
                 raise TypeError(msg)

--- a/axonflow/client.py
+++ b/axonflow/client.py
@@ -32,6 +32,7 @@ import json
 import logging
 import os
 import re
+import secrets
 from collections.abc import AsyncIterator, Coroutine, Iterator
 from dataclasses import dataclass
 from datetime import datetime
@@ -369,6 +370,7 @@ class AxonFlow:
             if not client_id:
                 msg = "client_id is required in demo mode (AXONFLOW_DEMO=1)"
                 raise TypeError(msg)
+            client_id = f"{client_id}-{secrets.token_hex(3)}"
 
         if isinstance(mode, str):
             mode = Mode(mode)

--- a/axonflow/client.py
+++ b/axonflow/client.py
@@ -32,7 +32,6 @@ import json
 import logging
 import os
 import re
-import secrets
 from collections.abc import AsyncIterator, Coroutine, Iterator
 from dataclasses import dataclass
 from datetime import datetime
@@ -365,12 +364,11 @@ class AxonFlow:
             msg = "endpoint is required (or set AXONFLOW_AGENT_URL environment variable)"
             raise TypeError(msg)
 
-        if os.environ.get("AXONFLOW_DEMO") == "1":
-            resolved_endpoint = "https://demo.getaxonflow.com"
+        if os.environ.get("AXONFLOW_TRY") == "1":
+            resolved_endpoint = "https://try.getaxonflow.com"
             if not client_id:
-                msg = "client_id is required in demo mode (AXONFLOW_DEMO=1)"
+                msg = "client_id is required in try mode (AXONFLOW_TRY=1)"
                 raise TypeError(msg)
-            client_id = f"{client_id}-{secrets.token_hex(3)}"
 
         if isinstance(mode, str):
             mode = Mode(mode)

--- a/axonflow/community.py
+++ b/axonflow/community.py
@@ -1,0 +1,25 @@
+"""Community SaaS registration helper for try.getaxonflow.com."""
+
+import httpx
+
+
+TRY_ENDPOINT = "https://try.getaxonflow.com"
+
+
+def register_try(label: str = "", endpoint: str = TRY_ENDPOINT) -> dict:
+    """Register for a free evaluation tenant on try.getaxonflow.com.
+
+    Returns dict with keys: tenant_id, secret, secret_prefix, expires_at, endpoint, note.
+    Store the secret securely — it is shown only once.
+
+    Args:
+        label: Optional human-readable name for the registration.
+        endpoint: Override the default endpoint (for local testing).
+    """
+    response = httpx.post(
+        f"{endpoint}/api/v1/register",
+        json={"label": label} if label else {},
+        timeout=10.0,
+    )
+    response.raise_for_status()
+    return response.json()

--- a/axonflow/community.py
+++ b/axonflow/community.py
@@ -1,11 +1,15 @@
 """Community SaaS registration helper for try.getaxonflow.com."""
 
+from __future__ import annotations
+
+from typing import Any
+
 import httpx
 
 TRY_ENDPOINT = "https://try.getaxonflow.com"
 
 
-def register_try(label: str = "", endpoint: str = TRY_ENDPOINT) -> dict:
+def register_try(label: str = "", endpoint: str = TRY_ENDPOINT) -> dict[str, Any]:
     """Register for a free evaluation tenant on try.getaxonflow.com.
 
     Returns dict with keys: tenant_id, secret, secret_prefix, expires_at, endpoint, note.
@@ -21,4 +25,5 @@ def register_try(label: str = "", endpoint: str = TRY_ENDPOINT) -> dict:
         timeout=10.0,
     )
     response.raise_for_status()
-    return response.json()
+    data: dict[str, Any] = response.json()
+    return data

--- a/axonflow/community.py
+++ b/axonflow/community.py
@@ -2,7 +2,6 @@
 
 import httpx
 
-
 TRY_ENDPOINT = "https://try.getaxonflow.com"
 
 

--- a/axonflow/telemetry.py
+++ b/axonflow/telemetry.py
@@ -87,6 +87,7 @@ def _classify_endpoint(url: str | None) -> str:  # noqa: PLR0911
     """Classify the configured AxonFlow endpoint for analytics (#1525).
 
     Returns one of:
+        ``"community-saas"``    — try.getaxonflow.com shared evaluation server
         ``"localhost"``         — localhost, 127.0.0.1, ::1, 0.0.0.0, ``*.localhost``
         ``"private_network"``   — RFC1918 ranges, link-local, ``*.local``,
                                   ``*.internal``, ``*.lan``, ``*.intranet``
@@ -95,6 +96,8 @@ def _classify_endpoint(url: str | None) -> str:  # noqa: PLR0911
 
     The raw URL is never sent — only the classification. See issue #1525.
     """
+    if os.environ.get("AXONFLOW_TRY") == "1":
+        return "community-saas"
     if not url:
         return "unknown"
     try:


### PR DESCRIPTION
Addresses https://github.com/getaxonflow/axonflow-enterprise/issues/1500.

## Changes

**Commit 1 — demo mode:** When `AXONFLOW_DEMO=1` is set, the client overrides `endpoint` to the public demo instance (`https://demo.getaxonflow.com`, placeholder URL pending the instance being stood up) and makes `client_id` mandatory.

**Commit 2 — random suffix:** In demo mode, a 6-character random hex suffix is appended to the provided `client_id` (e.g. `acme` → `acme-3f9a1c`). This gives each evaluator session a unique namespace on the shared demo instance without requiring them to choose a globally unique ID.

## Notes

- No behavior change when `AXONFLOW_DEMO` is unset.
- Demo URL is a placeholder — PRs will be updated with the real URL before merge.