### PR TITLE
fix: reject client_secret without client_id to prevent wrong-tenant data

### DIFF
--- a/axonflow/client.py
+++ b/axonflow/client.py
@@ -394,7 +394,8 @@ class AxonFlow:
         if client_secret and not client_id:
             raise ValueError(
                 "client_id is required when client_secret is set. "
-                "Set client_id to your tenant identity to avoid data being stored under the wrong tenant."
+                "Set client_id to your tenant identity to avoid "
+                "data being stored under the wrong tenant."
             )
         effective_client_id = client_id or "community"
         credentials = f"{effective_client_id}:{client_secret or ''}"

--- a/axonflow/client.py
+++ b/axonflow/client.py
@@ -390,6 +390,12 @@ class AxonFlow:
         }
         # Always send Basic auth — server derives tenant from clientId.
         # Uses effective client_id ("community" default when not configured).
+        # Reject client_secret without client_id — licensed mode must specify tenant.
+        if client_secret and not client_id:
+            raise ValueError(
+                "client_id is required when client_secret is set. "
+                "Set client_id to your tenant identity to avoid data being stored under the wrong tenant."
+            )
         effective_client_id = client_id or "community"
         credentials = f"{effective_client_id}:{client_secret or ''}"
         encoded = base64.b64encode(credentials.encode()).decode()

--- a/axonflow/client.py
+++ b/axonflow/client.py
@@ -392,11 +392,12 @@ class AxonFlow:
         # Uses effective client_id ("community" default when not configured).
         # Reject client_secret without client_id — licensed mode must specify tenant.
         if client_secret and not client_id:
-            raise ValueError(
+            msg = (
                 "client_id is required when client_secret is set. "
                 "Set client_id to your tenant identity to avoid "
                 "data being stored under the wrong tenant."
             )
+            raise ValueError(msg)
         effective_client_id = client_id or "community"
         credentials = f"{effective_client_id}:{client_secret or ''}"
         encoded = base64.b64encode(credentials.encode()).decode()


### PR DESCRIPTION
## Summary

Reject `client_secret`/`clientSecret` when `client_id`/`clientId` is not set. Without this check, the SDK silently uses `community` as the tenant identity, causing all licensed data to be stored under the wrong tenant.

Three valid configurations:
- Neither set → community mode (`clientId=community`, no license)
- `clientId` only → community mode with custom tenant
- Both set → licensed mode with explicit tenant

Aligns with getaxonflow/axonflow-enterprise#1492 unified identity model.

## Test plan

- [ ] `client_secret` without `client_id` throws clear error
- [ ] `client_id` without `client_secret` works (community with custom tenant)
- [ ] Both omitted works (community mode)
- [ ] Both set works (licensed mode)