### PR TITLE
feat: SDK v6.1.0 — tool aliases, localhost telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the AxonFlow Python SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [6.1.0] - 2026-04-08
+## [6.1.0] - 2026-04-06
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the AxonFlow Python SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.0] - 2026-04-08
+
+### Added
+
+- **`check_tool_input()` / `check_tool_output()`** — generic aliases for tool governance. Existing `mcp_check_input()` / `mcp_check_output()` remain supported.
+
+### Changed
+
+- Anonymous telemetry is now enabled by default for all endpoints, including localhost/self-hosted evaluation. Opt out with `DO_NOT_TRACK=1` or `AXONFLOW_TELEMETRY=off`.
+
+---
+
 ## [6.0.0] - 2026-04-05
 
 ### BREAKING CHANGES

--- a/axonflow/_version.py
+++ b/axonflow/_version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the AxonFlow SDK version."""
 
-__version__ = "6.0.0"
+__version__ = "6.1.0"

--- a/axonflow/client.py
+++ b/axonflow/client.py
@@ -1258,6 +1258,16 @@ class AxonFlow:
 
         return MCPCheckInputResponse(**data)
 
+    async def check_tool_input(
+        self,
+        connector_type: str,
+        statement: str,
+        operation: str = "execute",
+        parameters: dict[str, Any] | None = None,
+    ) -> MCPCheckInputResponse:
+        """Alias for :meth:`mcp_check_input`. Validates tool input against configured policies."""
+        return await self.mcp_check_input(connector_type, statement, operation, parameters)
+
     async def mcp_check_output(
         self,
         connector_type: str,
@@ -1312,6 +1322,19 @@ class AxonFlow:
             raise ConnectorError(error_msg, connector_type, "check-output")
 
         return MCPCheckOutputResponse(**data)
+
+    async def check_tool_output(
+        self,
+        connector_type: str,
+        response_data: list[dict[str, Any]] | None = None,
+        message: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        row_count: int = 0,
+    ) -> MCPCheckOutputResponse:
+        """Alias for :meth:`mcp_check_output`. Validates tool output against configured policies."""
+        return await self.mcp_check_output(
+            connector_type, response_data, message, metadata, row_count
+        )
 
     async def generate_plan(
         self,
@@ -6505,6 +6528,33 @@ class SyncAxonFlow:
         row_count: int = 0,
     ) -> MCPCheckOutputResponse:
         """Validate MCP response data against configured policies."""
+        return self._run_sync(
+            self._async_client.mcp_check_output(
+                connector_type, response_data, message, metadata, row_count
+            )
+        )
+
+    def check_tool_input(
+        self,
+        connector_type: str,
+        statement: str,
+        operation: str = "execute",
+        parameters: dict[str, Any] | None = None,
+    ) -> MCPCheckInputResponse:
+        """Alias for :meth:`mcp_check_input`. Validates tool input against configured policies."""
+        return self._run_sync(
+            self._async_client.mcp_check_input(connector_type, statement, operation, parameters)
+        )
+
+    def check_tool_output(
+        self,
+        connector_type: str,
+        response_data: list[dict[str, Any]] | None = None,
+        message: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        row_count: int = 0,
+    ) -> MCPCheckOutputResponse:
+        """Alias for :meth:`mcp_check_output`. Validates tool output against configured policies."""
         return self._run_sync(
             self._async_client.mcp_check_output(
                 connector_type, response_data, message, metadata, row_count

--- a/axonflow/telemetry.py
+++ b/axonflow/telemetry.py
@@ -74,7 +74,6 @@ def _detect_platform_version(endpoint: str) -> str | None:
     return None
 
 
-
 def _normalize_arch(arch: str) -> str:
     """Normalize architecture names to match other SDKs."""
     if arch == "aarch64":

--- a/axonflow/telemetry.py
+++ b/axonflow/telemetry.py
@@ -74,17 +74,6 @@ def _detect_platform_version(endpoint: str) -> str | None:
     return None
 
 
-def _is_localhost(endpoint: str) -> bool:
-    """Check whether the endpoint is a localhost address."""
-    try:
-        from urllib.parse import urlparse  # noqa: PLC0415
-
-        host = urlparse(endpoint).hostname or ""
-    except ValueError:
-        return False
-    else:
-        return host in ("localhost", "127.0.0.1", "::1")
-
 
 def _normalize_arch(arch: str) -> str:
     """Normalize architecture names to match other SDKs."""
@@ -158,10 +147,6 @@ def send_telemetry_ping(
         debug: When ``True``, log debug-level messages about the ping.
     """
     if not _is_telemetry_enabled(mode, telemetry_enabled, has_credentials):
-        return
-
-    # Suppress telemetry for localhost endpoints unless explicitly enabled.
-    if telemetry_enabled is not True and _is_localhost(endpoint):
         return
 
     logger.info(


### PR DESCRIPTION
## Summary
- `check_tool_input()` / `check_tool_output()` aliases for generic tool governance (existing `mcp_check_input` / `mcp_check_output` remain supported)
- Anonymous telemetry now enabled by default for all endpoints, including localhost/self-hosted evaluation. Opt out with `DO_NOT_TRACK=1` or `AXONFLOW_TELEMETRY=off`.

## Test plan
- [ ] `pytest tests/test_telemetry.py` — telemetry changes verified
- [ ] Alias delegation verified via existing mcp_check tests
- [ ] E2E: governed-tools Python example passes 8/8 tests