### PR TITLE
chore: use hello@getaxonflow.com as canonical contact email

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at dev@getaxonflow.com. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at hello@getaxonflow.com. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,7 @@ By contributing to AxonFlow Python SDK, you agree that your contributions will b
 If you have questions about contributing, feel free to:
 
 - Open a discussion on GitHub
-- Email us at dev@getaxonflow.com
+- Email us at hello@getaxonflow.com
 - Check our documentation at https://docs.getaxonflow.com
 
 Thank you for contributing to AxonFlow!

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ For enterprise features, contact [sales@getaxonflow.com](mailto:sales@getaxonflo
 
 - **Documentation**: https://docs.getaxonflow.com
 - **Issues**: https://github.com/getaxonflow/axonflow-sdk-python/issues
-- **Email**: dev@getaxonflow.com
+- **Email**: hello@getaxonflow.com
 
 If you are evaluating AxonFlow in a company setting and cannot open a public issue, you can share feedback or blockers confidentially here:
 [Anonymous evaluation feedback form](https://getaxonflow.com/feedback)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,10 @@ description = "AxonFlow Python SDK - Enterprise AI Governance in 3 Lines of Code
 readme = "README.md"
 license = {text = "MIT"}
 authors = [
-    {name = "AxonFlow", email = "dev@getaxonflow.com"}
+    {name = "AxonFlow", email = "hello@getaxonflow.com"}
 ]
 maintainers = [
-    {name = "AxonFlow", email = "dev@getaxonflow.com"}
+    {name = "AxonFlow", email = "hello@getaxonflow.com"}
 ]
 keywords = [
     "ai", "governance", "llm", "openai", "anthropic", "bedrock",


### PR DESCRIPTION
Consolidate contact emails to a single canonical address: hello@getaxonflow.com.

- dev@ and team@ retired across user-facing surfaces
- security@ kept separate for vulnerability disclosure (not touched here)