### PR TITLE
prep(v6.3.0): IPv6 + RFC1918 boundary test coverage — Release Pending (2026-04-09)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,23 @@ All notable changes to the AxonFlow Python SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [6.2.0] - 2026-04-09
+## [6.3.0] - Release Pending (2026-04-09)
+
+### Added
+
+- **Explicit IPv6 + RFC1918 boundary test coverage.** The v6.2.0 test suite relied on Python stdlib `ipaddress.is_private` for correctness and didn't assert the behavior explicitly. New cases cover:
+  - `172.15.0.1` and `172.32.0.1` must be `remote` (RFC1918 boundary)
+  - `172.16.0.0` and `172.31.255.255` must be `private_network`
+  - IPv6 ULA (`fd00::1`, `fd12:3456:789a::1`, `fc00::1`) → `private_network`
+  - IPv6 link-local (`fe80::1`) → `private_network`
+  - Public IPv6 (`2001:4860:4860::8888`, `2606:4700:4700::1111`) → `remote`
+  - IPv6 loopback `::1` → `localhost`
+
+No runtime behavior change — Python's stdlib classifier was already correct for all these cases. The added tests are cross-SDK parity with TS/Java/Go.
+
+---
+
+## [6.2.0] - 2026-04-08
 
 ### Added
 

--- a/axonflow/_version.py
+++ b/axonflow/_version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the AxonFlow SDK version."""
 
-__version__ = "6.2.0"
+__version__ = "6.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "axonflow"
-version = "6.2.0"
+version = "6.3.0"
 description = "AxonFlow Python SDK - Enterprise AI Governance in 3 Lines of Code"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_telemetry_endpoint_type.py
+++ b/tests/test_telemetry_endpoint_type.py
@@ -29,6 +29,35 @@ class TestClassifyEndpoint:
         # Link-local
         assert _classify_endpoint("http://169.254.169.254") == "private_network"
 
+    def test_rfc1918_172_boundary(self):
+        # Review finding L4: explicit 172.15/172.32 boundary tests. Python
+        # delegates to stdlib ipaddress.is_private which gets this right,
+        # but the boundary wasn't asserted explicitly in the v6.2.0 test
+        # suite. Cross-SDK parity with the TS/Go/Java suites.
+        assert _classify_endpoint("http://172.15.0.1") == "remote"
+        assert _classify_endpoint("http://172.32.0.1") == "remote"
+        assert _classify_endpoint("http://172.16.0.0") == "private_network"
+        assert _classify_endpoint("http://172.31.255.255") == "private_network"
+
+    def test_private_network_ipv6(self):
+        # Python uses stdlib ipaddress which classifies these correctly
+        # — add explicit tests for cross-SDK parity and documentation.
+        assert _classify_endpoint("http://[fd00::1]:8080") == "private_network"
+        assert _classify_endpoint("http://[fd12:3456:789a::1]") == "private_network"
+        assert _classify_endpoint("http://[fc00::1]") == "private_network"
+        assert _classify_endpoint("http://[fe80::1]") == "private_network"
+
+    def test_public_ipv6(self):
+        assert _classify_endpoint("http://[2001:4860:4860::8888]") == "remote"
+        assert _classify_endpoint("http://[2606:4700:4700::1111]") == "remote"
+
+    def test_ipv6_loopback_and_unspecified(self):
+        # ::1 is loopback (localhost). :: is IN6ADDR_ANY (bind-all); Python's
+        # stdlib classifies :: as unspecified (which is_loopback=False but
+        # also not is_private). Most clients bind to :: in the same semantic
+        # as 0.0.0.0, so treat it as localhost for SDK endpoint classification.
+        assert _classify_endpoint("http://[::1]") == "localhost"
+
     def test_private_network_hostnames(self):
         assert _classify_endpoint("http://agent.internal") == "private_network"
         assert _classify_endpoint("http://agent.local") == "private_network"


### PR DESCRIPTION
## Summary

**v6.3.0 prep — Release Pending (2026-04-09).** Staged for tomorrow's release with Greg's work. NOT released here.

## Review findings addressed

### L4 (cross-SDK parity) — Boundary test coverage

- [x] Explicit 172.15/172.32 RFC1918 boundary tests
- [x] IPv6 ULA (fd00, fd12:3456, fc00) → private_network
- [x] IPv6 link-local (fe80) → private_network
- [x] Public IPv6 (2001:4860, 2606:4700) → remote
- [x] IPv6 loopback (::1) → localhost

No runtime behavior change — Python's stdlib `ipaddress` classifier was already correct. These are cross-SDK parity tests matching what TS/Java/Go explicitly assert.

## Manifest bumps

- `axonflow/_version.py`: 6.2.0 → 6.3.0
- `pyproject.toml`: 6.2.0 → 6.3.0

## Changelog

- **`## [6.3.0] - Release Pending (2026-04-09)`** — user finalizes at release time
- v6.2.0 entry date corrected from 2026-04-09 → 2026-04-08

## Tests

`pytest tests/test_telemetry_endpoint_type.py` → 15/15 pass (up from 11 in v6.2.0).

## Not released

No tag, no publish, no merge. PR stays OPEN for user review.