### PR TITLE
feat: rich ApproveStepResponse / RejectStepResponse (v6.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [6.6.0] - 2026-04-22
 
+### Added
+
+- **Rich `ApproveStepResponse` / `RejectStepResponse`** — both pydantic models
+  now carry the same shape as the step-gate response: `decision` resolves to
+  `"allow"` / `"block"`, `retry_context` mirrors the gate response retry state,
+  `approved_by` / `approved_at` / `rejected_by` / `rejected_at` carry reviewer
+  identity, `approval_id` is the deterministic HITL queue UUID, and
+  `policies_matched` reconstructs the governance trail. Legacy fields
+  (`workflow_id`, `step_id`, `status`) remain for back-compat; every new field
+  is optional so older server responses still deserialize cleanly.
+- **`plan_id` on approve/reject responses** — populated when the response
+  comes from the MAP plan-scoped endpoint; empty on WCP plane responses.
+  Same models work across both endpoints.
+
 ### Deprecated
 
 - `DO_NOT_TRACK=1` as an AxonFlow telemetry opt-out — scheduled for removal after 2026-05-05 in the next major release. Use `AXONFLOW_TELEMETRY=off` instead. The SDK emits a one-line migration warning when `DO_NOT_TRACK=1` is the active control and `AXONFLOW_TELEMETRY=off` is not also set.
+
+### Unchanged
+
+- `approve_step(workflow_id, step_id)` / `reject_step(workflow_id, step_id, reason)`
+  method signatures are unchanged — only the response fields grew.
 
 ## [6.5.0] - 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`plan_id` on approve/reject responses** — populated when the response
   comes from the MAP plan-scoped endpoint; empty on WCP plane responses.
   Same models work across both endpoints.
+- **`get_pending_plan_approvals`** — new client method that lists MAP-plane
+  pending approvals (`GET /api/v1/plans/approvals/pending`), the counterpart
+  of `get_pending_approvals` for the WCP plane. Accepts an optional
+  `plan_id` argument so reviewer tools can scope the listing to one plan.
+  Available on Evaluation+ licenses (same tier gate as the MAP step
+  approve/reject endpoints). Sync wrapper exposed via
+  `SyncAxonFlow.get_pending_plan_approvals`.
+- **`PendingApproval.plan_id`** — populated on MAP-plane entries, `None` on
+  WCP-plane entries. Mirrors the approve/reject asymmetry. `PendingApproval`
+  also gains `step_index`, `decision`, `decision_reason`, `policies_matched`,
+  `step_input`, and `approval_status` so reviewer tools can render the full
+  approval context without a second request.
+
+### Fixed
+
+- **`approve_step` / `reject_step` / `get_pending_approvals` endpoint URLs** —
+  all three previously targeted non-existent paths under
+  `/api/v1/workflow-control/` and would fail against a real AxonFlow server.
+  Corrected to the canonical `/api/v1/workflows/{id}/steps/{step_id}/(approve|reject)`
+  and `/api/v1/workflows/approvals/pending` routes. Customers using these
+  methods against a live deployment were receiving 404s; this release makes
+  them work.
+- **`PendingApprovalsResponse` field names aligned with the wire shape** —
+  the model previously declared `approvals` and `total`, which never matched
+  the server response (`pending_approvals` and `count`). Renamed fields.
+  Callers that read `response.approvals` or `response.total` must update to
+  `response.pending_approvals` / `response.count`.
 
 ### Deprecated
 

--- a/axonflow/_version.py
+++ b/axonflow/_version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the AxonFlow SDK version."""
 
-__version__ = "6.5.0"
+__version__ = "6.6.0"

--- a/axonflow/client.py
+++ b/axonflow/client.py
@@ -4606,7 +4606,7 @@ class AxonFlow:
         """
         query = f"limit={limit}"
         if plan_id:
-            query += f"&plan_id={plan_id}"
+            query += f"&plan_id={quote(plan_id, safe='')}"
         path = f"/api/v1/plans/approvals/pending?{query}"
 
         response = await self._orchestrator_request("GET", path)

--- a/axonflow/client.py
+++ b/axonflow/client.py
@@ -334,6 +334,37 @@ class HealthResponse:
         return any(c.name == name for c in self.capabilities)
 
 
+def _parse_pending_approvals_response(response: dict[str, Any]) -> PendingApprovalsResponse:
+    """Parse the server pending-approvals response into the typed model.
+
+    Shared by ``get_pending_approvals`` (WCP plane) and
+    ``get_pending_plan_approvals`` (MAP plane) — identical wire shape, the
+    difference is just whether ``plan_id`` is populated per-entry.
+    """
+    approvals = [
+        PendingApproval(
+            workflow_id=a["workflow_id"],
+            workflow_name=a["workflow_name"],
+            plan_id=a.get("plan_id"),
+            step_id=a["step_id"],
+            step_index=a.get("step_index", 0),
+            step_name=a.get("step_name"),
+            step_type=a.get("step_type"),
+            decision=a.get("decision", "require_approval"),
+            decision_reason=a.get("decision_reason"),
+            policies_matched=a.get("policies_matched"),
+            step_input=a.get("step_input"),
+            approval_status=a.get("approval_status"),
+            created_at=a["created_at"],
+        )
+        for a in response.get("pending_approvals", [])
+    ]
+    return PendingApprovalsResponse(
+        pending_approvals=approvals,
+        count=response.get("count", len(approvals)),
+    )
+
+
 def _build_audit_search_body(request: AuditSearchRequest) -> dict[str, Any]:
     """Build the POST /api/v1/audit/search body from an AuditSearchRequest.
 
@@ -4459,7 +4490,7 @@ class AxonFlow:
         """
         response = await self._orchestrator_request(
             "POST",
-            f"/api/v1/workflow-control/{workflow_id}/steps/{step_id}/approve",
+            f"/api/v1/workflows/{workflow_id}/steps/{step_id}/approve",
             json_data={},
         )
         if not isinstance(response, dict):
@@ -4500,7 +4531,7 @@ class AxonFlow:
 
         response = await self._orchestrator_request(
             "POST",
-            f"/api/v1/workflow-control/{workflow_id}/steps/{step_id}/reject",
+            f"/api/v1/workflows/{workflow_id}/steps/{step_id}/reject",
             json_data=body,
         )
         if not isinstance(response, dict):
@@ -4517,7 +4548,13 @@ class AxonFlow:
         self,
         limit: int = 20,
     ) -> PendingApprovalsResponse:
-        """Get all pending approvals across workflows.
+        """Get all pending approvals across workflows — the WCP-plane listing.
+
+        Use :meth:`get_pending_plan_approvals` for the MAP-plane listing
+        (scopes to MAP-backed workflows and populates ``plan_id`` on every
+        entry).
+
+        Available on Evaluation+ licenses.
 
         Args:
             limit: Maximum number of pending approvals to return (default: 20)
@@ -4527,33 +4564,57 @@ class AxonFlow:
 
         Example:
             >>> result = await client.get_pending_approvals(limit=10)
-            >>> for approval in result.approvals:
+            >>> for approval in result.pending_approvals:
             ...     print(f"{approval.workflow_name}/{approval.step_name}: "
             ...           f"pending since {approval.created_at}")
         """
-        path = f"/api/v1/workflow-control/pending-approvals?limit={limit}"
+        path = f"/api/v1/workflows/approvals/pending?limit={limit}"
 
         response = await self._orchestrator_request("GET", path)
         if not isinstance(response, dict):
             msg = "Unexpected response type from get pending approvals"
             raise TypeError(msg)
 
-        approvals = [
-            PendingApproval(
-                workflow_id=a["workflow_id"],
-                workflow_name=a["workflow_name"],
-                step_id=a["step_id"],
-                step_name=a["step_name"],
-                step_type=a["step_type"],
-                created_at=a["created_at"],
-            )
-            for a in response.get("approvals", [])
-        ]
+        return _parse_pending_approvals_response(response)
 
-        return PendingApprovalsResponse(
-            approvals=approvals,
-            total=response.get("total", len(approvals)),
-        )
+    async def get_pending_plan_approvals(
+        self,
+        limit: int = 20,
+        plan_id: str | None = None,
+    ) -> PendingApprovalsResponse:
+        """List pending approvals for MAP-backed workflows.
+
+        The MAP-plane counterpart of :meth:`get_pending_approvals`. Every
+        returned entry has ``plan_id`` populated; WCP-only approvals are not
+        returned.
+
+        Requires an Evaluation or Enterprise license (same tier gate as the
+        MAP step approve/reject endpoints).
+
+        Args:
+            limit: Maximum number of pending approvals to return (default: 20)
+            plan_id: Optional plan id — when set, scopes the listing to a
+                single plan.
+
+        Returns:
+            PendingApprovalsResponse with list of MAP-plane pending approvals
+
+        Example:
+            >>> result = await client.get_pending_plan_approvals(plan_id="plan-abc123")
+            >>> for approval in result.pending_approvals:
+            ...     print(f"Plan {approval.plan_id} step {approval.step_id} awaiting approval")
+        """
+        query = f"limit={limit}"
+        if plan_id:
+            query += f"&plan_id={plan_id}"
+        path = f"/api/v1/plans/approvals/pending?{query}"
+
+        response = await self._orchestrator_request("GET", path)
+        if not isinstance(response, dict):
+            msg = "Unexpected response type from get pending plan approvals"
+            raise TypeError(msg)
+
+        return _parse_pending_approvals_response(response)
 
     # =========================================================================
     # HITL Queue API (Enterprise)
@@ -7276,6 +7337,19 @@ class SyncAxonFlow:
     ) -> PendingApprovalsResponse:
         """Get all pending approvals across workflows."""
         return self._run_sync(self._async_client.get_pending_approvals(limit))
+
+    def get_pending_plan_approvals(
+        self,
+        limit: int = 20,
+        plan_id: str | None = None,
+    ) -> PendingApprovalsResponse:
+        """List pending approvals for MAP-backed workflows (MAP-plane listing).
+
+        See :meth:`AxonFlow.get_pending_plan_approvals` for details.
+        """
+        return self._run_sync(
+            self._async_client.get_pending_plan_approvals(limit=limit, plan_id=plan_id)
+        )
 
     # HITL Queue API sync wrappers (Enterprise)
 

--- a/axonflow/client.py
+++ b/axonflow/client.py
@@ -4472,26 +4472,37 @@ class AxonFlow:
         self,
         workflow_id: str,
         step_id: str,
+        comment: str = "",
     ) -> ApproveStepResponse:
         """Approve a workflow step that requires human approval.
+
+        The server requires ``comment`` with a minimum of 10 characters — it's
+        the audit-trail justification that every approval carries into the
+        workflow history. Callers should always supply a meaningful comment.
 
         Call this to approve a step that received a ``require_approval`` gate decision.
 
         Args:
             workflow_id: Workflow ID
             step_id: Step ID to approve
+            comment: Audit justification for the approval (min 10 chars server-side)
 
         Returns:
             ApproveStepResponse with approval confirmation
 
         Example:
-            >>> result = await client.approve_step("wf_123", "step-1")
+            >>> result = await client.approve_step(
+            ...     "wf_123", "step-1", comment="Approved after full audit review"
+            ... )
             >>> print(f"Step {result.step_id} status: {result.status}")
         """
+        body: dict[str, Any] = {}
+        if comment:
+            body["comment"] = comment
         response = await self._orchestrator_request(
             "POST",
             f"/api/v1/workflows/{workflow_id}/steps/{step_id}/approve",
-            json_data={},
+            json_data=body,
         )
         if not isinstance(response, dict):
             msg = "Unexpected response type from approve step"
@@ -7318,9 +7329,10 @@ class SyncAxonFlow:
         self,
         workflow_id: str,
         step_id: str,
+        comment: str = "",
     ) -> ApproveStepResponse:
         """Approve a workflow step that requires human approval."""
-        return self._run_sync(self._async_client.approve_step(workflow_id, step_id))
+        return self._run_sync(self._async_client.approve_step(workflow_id, step_id, comment))
 
     def reject_step(
         self,

--- a/axonflow/workflow.py
+++ b/axonflow/workflow.py
@@ -504,9 +504,7 @@ class PendingApproval(BaseModel):
     workflow_name: str = Field(..., description="Workflow name")
     plan_id: str | None = Field(
         default=None,
-        description=(
-            "MAP plan id — populated on MAP-plane entries; None on WCP-plane entries."
-        ),
+        description=("MAP plan id — populated on MAP-plane entries; None on WCP-plane entries."),
     )
     step_id: str = Field(..., description="Step ID awaiting approval")
     step_index: int = Field(default=0, description="Zero-based step index within the workflow")
@@ -515,13 +513,10 @@ class PendingApproval(BaseModel):
     decision: str = Field(
         default="require_approval",
         description=(
-            "Gate decision that paused the step — always require_approval for "
-            "pending entries"
+            "Gate decision that paused the step — always require_approval for pending entries"
         ),
     )
-    decision_reason: str | None = Field(
-        default=None, description="Why the step was paused"
-    )
+    decision_reason: str | None = Field(default=None, description="Why the step was paused")
     policies_matched: list[dict] | None = Field(
         default=None, description="Policies that triggered the approval requirement"
     )

--- a/axonflow/workflow.py
+++ b/axonflow/workflow.py
@@ -446,15 +446,9 @@ class ApproveStepResponse(BaseModel):
         default=None, description="Post-approval decision (allow / block / require_approval)"
     )
     reason: str | None = Field(default=None, description="Decision reason text")
-    approval_status: str | None = Field(
-        default=None, description="pending / approved / rejected"
-    )
-    approval_id: str | None = Field(
-        default=None, description="Deterministic HITL queue UUID"
-    )
-    approved_by: str | None = Field(
-        default=None, description="Identity that approved the step"
-    )
+    approval_status: str | None = Field(default=None, description="pending / approved / rejected")
+    approval_id: str | None = Field(default=None, description="Deterministic HITL queue UUID")
+    approved_by: str | None = Field(default=None, description="Identity that approved the step")
     approved_at: str | None = Field(
         default=None, description="ISO 8601 timestamp when the approval was persisted"
     )

--- a/axonflow/workflow.py
+++ b/axonflow/workflow.py
@@ -418,19 +418,83 @@ class PolicyMatch(BaseModel):
 
 
 class ApproveStepResponse(BaseModel):
-    """Response from approving a workflow step."""
+    """Response from approving a workflow step.
+
+    Starting with v6.6.0 the server returns the rich step-gate shape: ``decision``
+    resolves to ``"allow"`` once approved, ``retry_context`` mirrors the gate
+    response retry state, ``approved_by`` / ``approved_at`` carry the reviewer
+    identity, ``approval_id`` is the deterministic HITL queue entry UUID, and
+    ``policies_matched`` reconstructs the governance trail. The legacy
+    ``workflow_id`` / ``step_id`` / ``status`` fields remain for back-compat.
+
+    See ADR-046 (HITL response parity) — the same shape is returned by both the
+    WCP endpoint and the MAP plan-scoped equivalent.
+    """
+
+    model_config = ConfigDict(extra="allow")
 
     workflow_id: str = Field(..., description="Workflow ID")
+    plan_id: str | None = Field(
+        default=None,
+        description="MAP plan ID — populated on plan-scoped responses",
+    )
     step_id: str = Field(..., description="Step ID that was approved")
-    status: str = Field(..., description="Approval status")
+    status: str | None = Field(
+        default=None, description="Legacy status field (mirrors approval_status)"
+    )
+    decision: str | None = Field(
+        default=None, description="Post-approval decision (allow / block / require_approval)"
+    )
+    reason: str | None = Field(default=None, description="Decision reason text")
+    approval_status: str | None = Field(
+        default=None, description="pending / approved / rejected"
+    )
+    approval_id: str | None = Field(
+        default=None, description="Deterministic HITL queue UUID"
+    )
+    approved_by: str | None = Field(
+        default=None, description="Identity that approved the step"
+    )
+    approved_at: str | None = Field(
+        default=None, description="ISO 8601 timestamp when the approval was persisted"
+    )
+    policies_matched: list[PolicyMatch] | None = Field(
+        default=None, description="Policies that triggered the require_approval decision"
+    )
+    retry_context: RetryContext | None = Field(
+        default=None,
+        description="Retry / idempotency state — mirrors gate response",
+    )
+    message: str | None = Field(default=None, description="Human-readable summary")
 
 
 class RejectStepResponse(BaseModel):
-    """Response from rejecting a workflow step."""
+    """Response from rejecting a workflow step.
+
+    Symmetric with :class:`ApproveStepResponse` — ``decision`` resolves to
+    ``"block"``, ``rejected_by`` / ``rejected_at`` populate instead of
+    approved_*. See ADR-046.
+    """
+
+    model_config = ConfigDict(extra="allow")
 
     workflow_id: str = Field(..., description="Workflow ID")
+    plan_id: str | None = Field(default=None, description="MAP plan ID")
     step_id: str = Field(..., description="Step ID that was rejected")
-    status: str = Field(..., description="Rejection status")
+    status: str | None = Field(
+        default=None, description="Legacy status field (mirrors approval_status)"
+    )
+    decision: str | None = Field(default=None, description="Post-rejection decision (block)")
+    reason: str | None = Field(default=None, description="Decision reason text")
+    approval_status: str | None = Field(default=None)
+    approval_id: str | None = Field(default=None, description="Deterministic HITL queue UUID")
+    rejected_by: str | None = Field(default=None, description="Identity that rejected the step")
+    rejected_at: str | None = Field(default=None, description="ISO 8601 rejection timestamp")
+    policies_matched: list[PolicyMatch] | None = Field(default=None)
+    retry_context: RetryContext | None = Field(
+        default=None, description="Retry / idempotency state"
+    )
+    message: str | None = Field(default=None)
 
 
 class PendingApproval(BaseModel):

--- a/axonflow/workflow.py
+++ b/axonflow/workflow.py
@@ -545,4 +545,8 @@ class PendingApprovalsResponse(BaseModel):
     pending_approvals: list[PendingApproval] = Field(
         default_factory=list, description="List of pending approvals"
     )
-    count: int = Field(default=0, ge=0, description="Total count of pending approvals matching the scope")
+    count: int = Field(
+        default=0,
+        ge=0,
+        description="Total count of pending approvals matching the scope",
+    )

--- a/axonflow/workflow.py
+++ b/axonflow/workflow.py
@@ -517,10 +517,10 @@ class PendingApproval(BaseModel):
         ),
     )
     decision_reason: str | None = Field(default=None, description="Why the step was paused")
-    policies_matched: list[dict] | None = Field(
+    policies_matched: list[dict[str, Any]] | None = Field(
         default=None, description="Policies that triggered the approval requirement"
     )
-    step_input: dict | None = Field(
+    step_input: dict[str, Any] | None = Field(
         default=None, description="Step input payload (may be redacted)"
     )
     approval_status: str | None = Field(

--- a/axonflow/workflow.py
+++ b/axonflow/workflow.py
@@ -514,15 +514,23 @@ class PendingApproval(BaseModel):
     step_type: str | None = Field(default=None, description="Step type")
     decision: str = Field(
         default="require_approval",
-        description="Gate decision that paused the step — always require_approval for pending entries",
+        description=(
+            "Gate decision that paused the step — always require_approval for "
+            "pending entries"
+        ),
     )
-    decision_reason: str | None = Field(default=None, description="Why the step was paused")
+    decision_reason: str | None = Field(
+        default=None, description="Why the step was paused"
+    )
     policies_matched: list[dict] | None = Field(
         default=None, description="Policies that triggered the approval requirement"
     )
-    step_input: dict | None = Field(default=None, description="Step input payload (may be redacted)")
+    step_input: dict | None = Field(
+        default=None, description="Step input payload (may be redacted)"
+    )
     approval_status: str | None = Field(
-        default=None, description="Current approval state — pending for listed entries"
+        default=None,
+        description="Current approval state — pending for listed entries",
     )
     created_at: str = Field(..., description="When the approval was requested")
 

--- a/axonflow/workflow.py
+++ b/axonflow/workflow.py
@@ -492,20 +492,49 @@ class RejectStepResponse(BaseModel):
 
 
 class PendingApproval(BaseModel):
-    """A pending approval for a workflow step."""
+    """A pending approval for a workflow step.
+
+    Populated by both ``get_pending_approvals`` (WCP plane) and
+    ``get_pending_plan_approvals`` (MAP plane). The ``plan_id`` field is the
+    one intentional asymmetry between the two planes — populated on MAP-plane
+    entries, ``None`` on WCP-plane entries (mirrors ADR-046 parity rule).
+    """
 
     workflow_id: str = Field(..., description="Workflow ID")
     workflow_name: str = Field(..., description="Workflow name")
+    plan_id: str | None = Field(
+        default=None,
+        description=(
+            "MAP plan id — populated on MAP-plane entries; None on WCP-plane entries."
+        ),
+    )
     step_id: str = Field(..., description="Step ID awaiting approval")
-    step_name: str = Field(..., description="Step name")
-    step_type: str = Field(..., description="Step type")
+    step_index: int = Field(default=0, description="Zero-based step index within the workflow")
+    step_name: str | None = Field(default=None, description="Step name")
+    step_type: str | None = Field(default=None, description="Step type")
+    decision: str = Field(
+        default="require_approval",
+        description="Gate decision that paused the step — always require_approval for pending entries",
+    )
+    decision_reason: str | None = Field(default=None, description="Why the step was paused")
+    policies_matched: list[dict] | None = Field(
+        default=None, description="Policies that triggered the approval requirement"
+    )
+    step_input: dict | None = Field(default=None, description="Step input payload (may be redacted)")
+    approval_status: str | None = Field(
+        default=None, description="Current approval state — pending for listed entries"
+    )
     created_at: str = Field(..., description="When the approval was requested")
 
 
 class PendingApprovalsResponse(BaseModel):
-    """Response containing pending approvals."""
+    """Response containing pending approvals.
 
-    approvals: list[PendingApproval] = Field(
+    Shape matches the server wire contract: ``pending_approvals`` array +
+    ``count``.
+    """
+
+    pending_approvals: list[PendingApproval] = Field(
         default_factory=list, description="List of pending approvals"
     )
-    total: int = Field(default=0, ge=0, description="Total count of pending approvals")
+    count: int = Field(default=0, ge=0, description="Total count of pending approvals matching the scope")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "axonflow"
-version = "6.5.0"
+version = "6.6.0"
 description = "AxonFlow Python SDK - Enterprise AI Governance in 3 Lines of Code"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_wcp_approvals.py
+++ b/tests/test_wcp_approvals.py
@@ -56,7 +56,7 @@ class TestApproveStep:
     ) -> None:
         """Test approving a workflow step."""
         httpx_mock.add_response(
-            url="https://test.axonflow.com/api/v1/workflow-control/wf-123/steps/step-1/approve",
+            url="https://test.axonflow.com/api/v1/workflows/wf-123/steps/step-1/approve",
             json={
                 "workflow_id": "wf-123",
                 "step_id": "step-1",
@@ -78,7 +78,7 @@ class TestApproveStep:
     ) -> None:
         """Test that workflow_id and step_id default from args if not in response."""
         httpx_mock.add_response(
-            url="https://test.axonflow.com/api/v1/workflow-control/wf-456/steps/step-2/approve",
+            url="https://test.axonflow.com/api/v1/workflows/wf-456/steps/step-2/approve",
             json={
                 "status": "approved",
             },
@@ -101,7 +101,7 @@ class TestRejectStep:
     ) -> None:
         """Test rejecting a workflow step with a reason."""
         httpx_mock.add_response(
-            url="https://test.axonflow.com/api/v1/workflow-control/wf-123/steps/step-1/reject",
+            url="https://test.axonflow.com/api/v1/workflows/wf-123/steps/step-1/reject",
             json={
                 "workflow_id": "wf-123",
                 "step_id": "step-1",
@@ -123,7 +123,7 @@ class TestRejectStep:
     ) -> None:
         """Test rejecting a workflow step without a reason."""
         httpx_mock.add_response(
-            url="https://test.axonflow.com/api/v1/workflow-control/wf-123/steps/step-1/reject",
+            url="https://test.axonflow.com/api/v1/workflows/wf-123/steps/step-1/reject",
             json={
                 "workflow_id": "wf-123",
                 "step_id": "step-1",
@@ -142,7 +142,7 @@ class TestRejectStep:
     ) -> None:
         """Test that workflow_id and step_id default from args if not in response."""
         httpx_mock.add_response(
-            url="https://test.axonflow.com/api/v1/workflow-control/wf-789/steps/step-3/reject",
+            url="https://test.axonflow.com/api/v1/workflows/wf-789/steps/step-3/reject",
             json={
                 "status": "rejected",
             },
@@ -164,38 +164,44 @@ class TestGetPendingApprovals:
     ) -> None:
         """Test getting pending approvals."""
         httpx_mock.add_response(
-            url="https://test.axonflow.com/api/v1/workflow-control/pending-approvals?limit=20",
+            url="https://test.axonflow.com/api/v1/workflows/approvals/pending?limit=20",
             json={
-                "approvals": [
+                "pending_approvals": [
                     {
                         "workflow_id": "wf-123",
                         "workflow_name": "customer-support",
                         "step_id": "step-1",
+                        "step_index": 0,
                         "step_name": "Generate Response",
                         "step_type": "llm_call",
+                        "decision": "require_approval",
                         "created_at": "2026-02-07T10:00:00Z",
                     },
                     {
                         "workflow_id": "wf-456",
                         "workflow_name": "data-pipeline",
                         "step_id": "step-3",
+                        "step_index": 2,
                         "step_name": "Delete Records",
                         "step_type": "tool_call",
+                        "decision": "require_approval",
                         "created_at": "2026-02-07T11:00:00Z",
                     },
                 ],
-                "total": 2,
+                "count": 2,
             },
         )
 
         result = await client.get_pending_approvals()
         assert isinstance(result, PendingApprovalsResponse)
-        assert result.total == 2
-        assert len(result.approvals) == 2
-        assert result.approvals[0].workflow_id == "wf-123"
-        assert result.approvals[0].workflow_name == "customer-support"
-        assert result.approvals[0].step_name == "Generate Response"
-        assert result.approvals[1].step_type == "tool_call"
+        assert result.count == 2
+        assert len(result.pending_approvals) == 2
+        assert result.pending_approvals[0].workflow_id == "wf-123"
+        assert result.pending_approvals[0].workflow_name == "customer-support"
+        assert result.pending_approvals[0].step_name == "Generate Response"
+        assert result.pending_approvals[1].step_type == "tool_call"
+        # WCP entries must not carry plan_id
+        assert result.pending_approvals[0].plan_id is None
 
     @pytest.mark.asyncio
     async def test_get_pending_approvals_with_limit(
@@ -205,16 +211,16 @@ class TestGetPendingApprovals:
     ) -> None:
         """Test getting pending approvals with custom limit."""
         httpx_mock.add_response(
-            url="https://test.axonflow.com/api/v1/workflow-control/pending-approvals?limit=5",
+            url="https://test.axonflow.com/api/v1/workflows/approvals/pending?limit=5",
             json={
-                "approvals": [],
-                "total": 0,
+                "pending_approvals": [],
+                "count": 0,
             },
         )
 
         result = await client.get_pending_approvals(limit=5)
-        assert result.total == 0
-        assert result.approvals == []
+        assert result.count == 0
+        assert result.pending_approvals == []
 
     @pytest.mark.asyncio
     async def test_get_pending_approvals_empty(
@@ -224,16 +230,99 @@ class TestGetPendingApprovals:
     ) -> None:
         """Test getting pending approvals when none exist."""
         httpx_mock.add_response(
-            url="https://test.axonflow.com/api/v1/workflow-control/pending-approvals?limit=20",
+            url="https://test.axonflow.com/api/v1/workflows/approvals/pending?limit=20",
             json={
-                "approvals": [],
-                "total": 0,
+                "pending_approvals": [],
+                "count": 0,
             },
         )
 
         result = await client.get_pending_approvals()
-        assert result.total == 0
-        assert result.approvals == []
+        assert result.count == 0
+        assert result.pending_approvals == []
+
+
+class TestGetPendingPlanApprovals:
+    """Test get_pending_plan_approvals method — the MAP-plane listing (#1680)."""
+
+    @pytest.mark.asyncio
+    async def test_get_pending_plan_approvals(
+        self,
+        client: AxonFlow,
+        httpx_mock: HTTPXMock,
+    ) -> None:
+        """MAP-plane entries carry plan_id through the round trip."""
+        httpx_mock.add_response(
+            url="https://test.axonflow.com/api/v1/plans/approvals/pending?limit=20",
+            json={
+                "pending_approvals": [
+                    {
+                        "workflow_id": "wf_map_abc",
+                        "workflow_name": "map-confirm-plan-abc",
+                        "plan_id": "plan-abc",
+                        "step_id": "step_0_analyze",
+                        "step_index": 0,
+                        "step_name": "Analyze transaction",
+                        "step_type": "tool_call",
+                        "decision": "require_approval",
+                        "decision_reason": "High-value transaction",
+                        "created_at": "2026-04-22T10:00:00Z",
+                    },
+                ],
+                "count": 1,
+            },
+        )
+
+        result = await client.get_pending_plan_approvals()
+        assert isinstance(result, PendingApprovalsResponse)
+        assert result.count == 1
+        assert len(result.pending_approvals) == 1
+        assert result.pending_approvals[0].plan_id == "plan-abc"
+        assert result.pending_approvals[0].decision_reason == "High-value transaction"
+
+    @pytest.mark.asyncio
+    async def test_get_pending_plan_approvals_plan_id_filter(
+        self,
+        client: AxonFlow,
+        httpx_mock: HTTPXMock,
+    ) -> None:
+        """plan_id argument propagates to the query string."""
+        httpx_mock.add_response(
+            url="https://test.axonflow.com/api/v1/plans/approvals/pending?limit=20&plan_id=plan-abc",
+            json={"pending_approvals": [], "count": 0},
+        )
+
+        await client.get_pending_plan_approvals(plan_id="plan-abc")
+
+    @pytest.mark.asyncio
+    async def test_get_pending_plan_approvals_limit_and_plan_id(
+        self,
+        client: AxonFlow,
+        httpx_mock: HTTPXMock,
+    ) -> None:
+        """Both knobs propagate together."""
+        httpx_mock.add_response(
+            url="https://test.axonflow.com/api/v1/plans/approvals/pending?limit=3&plan_id=plan-x",
+            json={"pending_approvals": [], "count": 0},
+        )
+
+        await client.get_pending_plan_approvals(limit=3, plan_id="plan-x")
+
+    @pytest.mark.asyncio
+    async def test_get_pending_plan_approvals_empty(
+        self,
+        client: AxonFlow,
+        httpx_mock: HTTPXMock,
+    ) -> None:
+        """Empty list deserializes to an empty list (not None)."""
+        httpx_mock.add_response(
+            url="https://test.axonflow.com/api/v1/plans/approvals/pending?limit=20",
+            json={"pending_approvals": [], "count": 0},
+        )
+
+        result = await client.get_pending_plan_approvals()
+        assert result.count == 0
+        assert result.pending_approvals == []
 
 
 # =========================================================================
@@ -599,23 +688,55 @@ class TestSyncWrappers:
         """Test sync get_pending_approvals wrapper."""
         httpx_mock.add_response(
             json={
-                "approvals": [
+                "pending_approvals": [
                     {
                         "workflow_id": "wf-123",
                         "workflow_name": "test-wf",
                         "step_id": "step-1",
+                        "step_index": 0,
                         "step_name": "Test Step",
                         "step_type": "llm_call",
+                        "decision": "require_approval",
                         "created_at": "2026-02-07T10:00:00Z",
                     },
                 ],
-                "total": 1,
+                "count": 1,
             },
         )
 
         result = sync_client.get_pending_approvals(limit=10)
         assert isinstance(result, PendingApprovalsResponse)
-        assert result.total == 1
+        assert result.count == 1
+
+    def test_sync_get_pending_plan_approvals(
+        self,
+        sync_client: SyncAxonFlow,
+        httpx_mock: HTTPXMock,
+    ) -> None:
+        """Test sync get_pending_plan_approvals wrapper (MAP plane)."""
+        httpx_mock.add_response(
+            json={
+                "pending_approvals": [
+                    {
+                        "workflow_id": "wf-map",
+                        "workflow_name": "map-plan-1",
+                        "plan_id": "plan-1",
+                        "step_id": "step-1",
+                        "step_index": 0,
+                        "step_name": "Test",
+                        "step_type": "tool_call",
+                        "decision": "require_approval",
+                        "created_at": "2026-04-22T10:00:00Z",
+                    },
+                ],
+                "count": 1,
+            },
+        )
+
+        result = sync_client.get_pending_plan_approvals(limit=10, plan_id="plan-1")
+        assert isinstance(result, PendingApprovalsResponse)
+        assert result.count == 1
+        assert result.pending_approvals[0].plan_id == "plan-1"
 
     def test_sync_rollback_plan(
         self,
@@ -772,12 +893,30 @@ class TestTypeModels:
         )
         assert approval.workflow_id == "wf-1"
         assert approval.step_type == "llm_call"
+        # plan_id defaults to None (WCP-plane entry shape)
+        assert approval.plan_id is None
+
+    def test_pending_approval_with_plan_id(self) -> None:
+        """Test PendingApproval carries plan_id through on MAP-plane entries (#1680)."""
+        approval = PendingApproval(
+            workflow_id="wf-map",
+            workflow_name="map-plan-1",
+            plan_id="plan-1",
+            step_id="step-1",
+            step_index=0,
+            decision="require_approval",
+            created_at="2026-04-22T10:00:00Z",
+        )
+        assert approval.plan_id == "plan-1"
+        # Ensures model_dump preserves plan_id so callers can serialize back
+        dumped = approval.model_dump()
+        assert dumped["plan_id"] == "plan-1"
 
     def test_pending_approvals_response_defaults(self) -> None:
         """Test PendingApprovalsResponse with defaults."""
         resp = PendingApprovalsResponse()
-        assert resp.approvals == []
-        assert resp.total == 0
+        assert resp.pending_approvals == []
+        assert resp.count == 0
 
     def test_rollback_plan_response(self) -> None:
         """Test RollbackPlanResponse model."""

--- a/tests/test_wcp_approvals.py
+++ b/tests/test_wcp_approvals.py
@@ -324,6 +324,26 @@ class TestGetPendingPlanApprovals:
         assert result.count == 0
         assert result.pending_approvals == []
 
+    @pytest.mark.asyncio
+    async def test_get_pending_plan_approvals_url_encodes_plan_id(
+        self,
+        client: AxonFlow,
+        httpx_mock: HTTPXMock,
+    ) -> None:
+        """plan_id with special characters must be URL-encoded on the wire.
+
+        Regression guard for #1680: raw string concatenation would let
+        characters like ``&`` or space slip into the URL and corrupt the
+        request. ``urllib.parse.quote(plan_id, safe='')`` percent-encodes
+        everything outside the unreserved set.
+        """
+        httpx_mock.add_response(
+            url="https://test.axonflow.com/api/v1/plans/approvals/pending?limit=20&plan_id=plan%20a%26b",
+            json={"pending_approvals": [], "count": 0},
+        )
+
+        await client.get_pending_plan_approvals(plan_id="plan a&b")
+
 
 # =========================================================================
 # Plan Rollback Tests (Feature 7)


### PR DESCRIPTION
## Summary

- Extend pydantic \`ApproveStepResponse\` / \`RejectStepResponse\` models with the new v7.4.0 platform fields. All rich fields are optional so older server responses still deserialize cleanly.
- \`plan_id\` populates on MAP-plane responses. Same models across both endpoints.
- Legacy \`workflow_id\` / \`step_id\` / \`status\` preserved.

Paired with axonflow-enterprise#1678. **Do not merge** until platform merges.

## Test plan

- [x] \`pytest tests/test_wcp_approvals.py tests/test_retry_context_idempotency.py\` — 78 tests pass
- [x] Pydantic \`model_validate\` round-trips the full v7.4.0 response shape
- [ ] Live verification against v7.4.0 platform (release-prep session)