### PR TITLE
fix(telemetry): flush on exit so short-lived processes deliver the ping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to the AxonFlow Python SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Telemetry delivery on short-lived processes.** `send_telemetry_ping`
+  spawned a daemon thread that was killed on interpreter shutdown before its
+  HTTP POST to the checkpoint completed. CLI one-liners, serverless handlers,
+  quickstart snippets, and cold-start functions silently dropped their
+  telemetry with no error visible to the caller. An `atexit` handler now
+  joins pending telemetry threads with a bounded timeout, so the ping is
+  guaranteed to either land or time out before the interpreter exits. The
+  pending-thread list is pruned on every append so long-lived processes that
+  instantiate many clients do not accumulate Thread objects.
+- **Telemetry budget no longer stacks.** The `/health` probe (2s) and the
+  checkpoint POST (3s) previously had independent timeouts, so the total
+  telemetry path could take up to ~5s — longer than the atexit flush
+  guaranteed to wait, reintroducing the short-lived-process drop on slow or
+  blackholed endpoints. Both network operations now share a single monotonic
+  deadline derived from `_TIMEOUT_SECONDS`, so the atexit flush budget
+  actually covers the complete path.
+
 ## [6.6.0] - 2026-04-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,22 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Telemetry delivery on short-lived processes.** `send_telemetry_ping`
-  spawned a daemon thread that was killed on interpreter shutdown before its
-  HTTP POST to the checkpoint completed. CLI one-liners, serverless handlers,
-  quickstart snippets, and cold-start functions silently dropped their
-  telemetry with no error visible to the caller. An `atexit` handler now
-  joins pending telemetry threads with a bounded timeout, so the ping is
-  guaranteed to either land or time out before the interpreter exits. The
-  pending-thread list is pruned on every append so long-lived processes that
-  instantiate many clients do not accumulate Thread objects.
-- **Telemetry budget no longer stacks.** The `/health` probe (2s) and the
-  checkpoint POST (3s) previously had independent timeouts, so the total
-  telemetry path could take up to ~5s — longer than the atexit flush
-  guaranteed to wait, reintroducing the short-lived-process drop on slow or
-  blackholed endpoints. Both network operations now share a single monotonic
-  deadline derived from `_TIMEOUT_SECONDS`, so the atexit flush budget
-  actually covers the complete path.
+- Telemetry pings now deliver reliably from short-lived processes (CLI, serverless, cold-starts).
+- Telemetry path is bounded at `_TIMEOUT_SECONDS` (3s) total; the `/health` probe and checkpoint POST share a single deadline instead of stacking.
 
 ## [6.6.0] - 2026-04-22
 

--- a/axonflow/telemetry.py
+++ b/axonflow/telemetry.py
@@ -19,6 +19,7 @@ import logging
 import os
 import platform
 import threading
+import time
 import uuid
 from urllib.parse import urlparse
 
@@ -96,13 +97,16 @@ def _is_telemetry_enabled(
     return mode != "sandbox"
 
 
-def _detect_platform_version(endpoint: str) -> str | None:
+def _detect_platform_version(endpoint: str, timeout: float = 2.0) -> str | None:
     """Detect platform version by calling the agent's /health endpoint.
 
-    Returns the version string or None on any failure.
+    Returns the version string or None on any failure. The caller passes a
+    timeout derived from the shared telemetry deadline so the health probe
+    and the checkpoint POST don't stack into a larger combined budget — see
+    issue #1692.
     """
     try:
-        resp = httpx.get(f"{endpoint}/health", timeout=2)
+        resp = httpx.get(f"{endpoint}/health", timeout=timeout)
         if resp.status_code == _HTTP_OK:
             body = resp.json()
             version = body.get("version")
@@ -194,12 +198,31 @@ def _build_payload(
 
 
 def _do_ping(url: str, mode: str, endpoint: str, debug: bool) -> None:
-    """Execute the HTTP POST (runs inside a daemon thread)."""
+    """Execute the HTTP POST (runs inside a daemon thread).
+
+    All HTTP operations share one monotonic deadline so that the atexit flush
+    handler's ``_TIMEOUT_SECONDS`` budget actually covers the complete
+    telemetry path. Previously the /health probe (2s) and the POST
+    (``_TIMEOUT_SECONDS``) each had independent timeouts, which meant the
+    thread's real worst case was ~5s and the 3s join could return while the
+    POST was still in flight — reintroducing the short-lived-process drop
+    bug on slow or blackholed endpoints. See issue #1692.
+    """
+    deadline = time.monotonic() + _TIMEOUT_SECONDS
     try:
-        platform_version = _detect_platform_version(endpoint) if endpoint else None
+        # Health probe uses remaining budget, capped so the POST still has time.
+        health_budget = min(1.0, max(0.0, deadline - time.monotonic()))
+        platform_version = None
+        if endpoint and health_budget > 0.1:
+            platform_version = _detect_platform_version(endpoint, timeout=health_budget)
         endpoint_type = _classify_endpoint(endpoint)
         payload = _build_payload(mode, platform_version, endpoint_type)
-        resp = httpx.post(url, json=payload, timeout=_TIMEOUT_SECONDS)
+
+        # POST uses all remaining budget.
+        post_budget = max(0.0, deadline - time.monotonic())
+        if post_budget < 0.1:
+            return
+        resp = httpx.post(url, json=payload, timeout=post_budget)
         if resp.status_code == _HTTP_OK:
             try:
                 body = resp.json()

--- a/axonflow/telemetry.py
+++ b/axonflow/telemetry.py
@@ -13,6 +13,7 @@ Override endpoint:
 
 from __future__ import annotations
 
+import atexit
 import ipaddress
 import logging
 import os
@@ -30,6 +31,30 @@ logger = logging.getLogger(__name__)
 _DEFAULT_CHECKPOINT_URL = "https://checkpoint.getaxonflow.com/v1/ping"
 _TIMEOUT_SECONDS = 3
 _HTTP_OK = 200
+
+# Flush-on-exit bookkeeping: track spawned telemetry threads so we can join
+# them on interpreter shutdown. Without this, a `daemon=True` thread is killed
+# before its HTTP POST completes in short-lived scripts (CLI one-liners,
+# serverless handlers, test harnesses), silently dropping telemetry.
+_pending_threads: list[threading.Thread] = []
+_pending_threads_lock = threading.Lock()
+_atexit_registered = False
+
+
+def _flush_pending_telemetry() -> None:
+    """Join any still-running telemetry threads on interpreter shutdown.
+
+    Bounded by the per-thread HTTP timeout (``_TIMEOUT_SECONDS``), so total
+    shutdown delay never exceeds the slowest ping's remaining budget.
+    Silent on all errors — telemetry must never disrupt shutdown.
+    """
+    with _pending_threads_lock:
+        threads = list(_pending_threads)
+    for t in threads:
+        try:
+            t.join(timeout=_TIMEOUT_SECONDS)
+        except Exception:
+            pass
 
 
 def _is_telemetry_enabled(
@@ -228,3 +253,14 @@ def send_telemetry_ping(
 
     t = threading.Thread(target=_do_ping, args=(url, mode, endpoint, debug), daemon=True)
     t.start()
+
+    # Register the thread for on-exit flush, and register the atexit handler
+    # once per process. Without this, short-lived processes (CLI scripts,
+    # serverless, quickstart one-liners) exit before the POST completes and
+    # the ping is silently dropped. See issue #1692.
+    global _atexit_registered
+    with _pending_threads_lock:
+        _pending_threads.append(t)
+        if not _atexit_registered:
+            atexit.register(_flush_pending_telemetry)
+            _atexit_registered = True

--- a/axonflow/telemetry.py
+++ b/axonflow/telemetry.py
@@ -14,6 +14,7 @@ Override endpoint:
 from __future__ import annotations
 
 import atexit
+import contextlib
 import ipaddress
 import logging
 import os
@@ -32,6 +33,11 @@ logger = logging.getLogger(__name__)
 _DEFAULT_CHECKPOINT_URL = "https://checkpoint.getaxonflow.com/v1/ping"
 _TIMEOUT_SECONDS = 3
 _HTTP_OK = 200
+# Minimum HTTP budget (seconds) — below this, skip the operation rather than
+# issue a request that is almost guaranteed to time out before any useful
+# work completes. Keeps the telemetry path from making "essentially zero
+# budget" calls when the shared deadline is nearly spent.
+_MIN_BUDGET_SECONDS = 0.1
 
 # Flush-on-exit bookkeeping: track spawned telemetry threads so we can join
 # them on interpreter shutdown. Without this, a `daemon=True` thread is killed
@@ -52,10 +58,10 @@ def _flush_pending_telemetry() -> None:
     with _pending_threads_lock:
         threads = list(_pending_threads)
     for t in threads:
-        try:
+        # Shutdown-path: any exception from join() must be swallowed silently
+        # to not mask the real shutdown reason with a spurious traceback.
+        with contextlib.suppress(Exception):
             t.join(timeout=_TIMEOUT_SECONDS)
-        except Exception:
-            pass
 
 
 def _is_telemetry_enabled(
@@ -213,14 +219,14 @@ def _do_ping(url: str, mode: str, endpoint: str, debug: bool) -> None:
         # Health probe uses remaining budget, capped so the POST still has time.
         health_budget = min(1.0, max(0.0, deadline - time.monotonic()))
         platform_version = None
-        if endpoint and health_budget > 0.1:
+        if endpoint and health_budget > _MIN_BUDGET_SECONDS:
             platform_version = _detect_platform_version(endpoint, timeout=health_budget)
         endpoint_type = _classify_endpoint(endpoint)
         payload = _build_payload(mode, platform_version, endpoint_type)
 
         # POST uses all remaining budget.
         post_budget = max(0.0, deadline - time.monotonic())
-        if post_budget < 0.1:
+        if post_budget < _MIN_BUDGET_SECONDS:
             return
         resp = httpx.post(url, json=payload, timeout=post_budget)
         if resp.status_code == _HTTP_OK:
@@ -281,7 +287,7 @@ def send_telemetry_ping(
     # once per process. Without this, short-lived processes (CLI scripts,
     # serverless, quickstart one-liners) exit before the POST completes and
     # the ping is silently dropped. See issue #1692.
-    global _atexit_registered
+    global _atexit_registered  # noqa: PLW0603  one-shot module-level registration flag
     with _pending_threads_lock:
         # Prune completed threads so the list stays bounded in long-lived
         # processes that instantiate many clients (e.g. per-request handlers).

--- a/axonflow/telemetry.py
+++ b/axonflow/telemetry.py
@@ -260,6 +260,9 @@ def send_telemetry_ping(
     # the ping is silently dropped. See issue #1692.
     global _atexit_registered
     with _pending_threads_lock:
+        # Prune completed threads so the list stays bounded in long-lived
+        # processes that instantiate many clients (e.g. per-request handlers).
+        _pending_threads[:] = [pt for pt in _pending_threads if pt.is_alive()]
         _pending_threads.append(t)
         if not _atexit_registered:
             atexit.register(_flush_pending_telemetry)

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -285,7 +285,11 @@ class TestSendTelemetryPing:
 
     @patch("axonflow.telemetry.httpx")
     def test_timeout_passed_to_post(self, mock_httpx: MagicMock) -> None:
-        """Verify the 3-second timeout is passed to httpx.post."""
+        """POST timeout is derived from the shared telemetry deadline, so it
+        is bounded by the total budget (``_TIMEOUT_SECONDS``) and comfortably
+        positive after the health probe. Under mocks the health probe returns
+        instantly, so the remaining budget stays close to the full 3s.
+        """
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {}
@@ -301,7 +305,10 @@ class TestSendTelemetryPing:
         _wait_for_threads()
 
         call_kwargs = mock_httpx.post.call_args[1]
-        assert call_kwargs["timeout"] == 3
+        # Total budget is 3s; health probe is mocked and returns instantly,
+        # so the POST should get essentially all of it. Allow slack for
+        # scheduler jitter.
+        assert 2.0 < call_kwargs["timeout"] <= 3.0
 
     @patch("axonflow.telemetry.httpx")
     def test_non_200_response_no_crash(self, mock_httpx: MagicMock) -> None:

--- a/tests/test_telemetry_short_lived.py
+++ b/tests/test_telemetry_short_lived.py
@@ -23,7 +23,7 @@ import sys
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import Any
+from typing import Any, ClassVar
 
 import pytest
 
@@ -38,14 +38,14 @@ def _free_port() -> int:
 class _CapturingHandler(BaseHTTPRequestHandler):
     """HTTP handler that captures POST bodies and serves /health."""
 
-    received: list[dict[str, Any]] = []
+    received: ClassVar[list[dict[str, Any]]] = []
 
     def do_POST(self) -> None:  # noqa: N802
         length = int(self.headers.get("Content-Length", 0))
         body = self.rfile.read(length) if length else b""
         try:
             payload = json.loads(body)
-        except Exception:
+        except Exception:  # noqa: BLE001  tolerate any malformed-body shape from test inputs
             payload = {}
         self.__class__.received.append(payload)
         self.send_response(200)
@@ -99,7 +99,7 @@ def test_telemetry_flushes_on_immediate_exit(mock_checkpoint: Any) -> None:
     env.pop("AXONFLOW_TELEMETRY", None)
     env["AXONFLOW_CHECKPOINT_URL"] = f"{base_url}/v1/ping"
 
-    result = subprocess.run(
+    result = subprocess.run(  # noqa: S603  sys.executable is trusted; args are literal
         [
             sys.executable,
             "-c",

--- a/tests/test_telemetry_short_lived.py
+++ b/tests/test_telemetry_short_lived.py
@@ -1,0 +1,133 @@
+"""Regression test for issue #1692: telemetry must be delivered even when the
+Python process exits immediately after client init.
+
+Root cause: ``threading.Thread(..., daemon=True)`` is killed when the interpreter
+shuts down. In short-lived scripts (CLI one-liners, serverless handlers, quickstart
+snippets, cold-start functions), the HTTP POST to checkpoint never completes.
+
+Fix: ``atexit`` handler that joins the telemetry thread with a short timeout.
+
+This test intentionally runs the SDK in a *subprocess* that exits immediately,
+so we exercise the real interpreter-shutdown path — not a mock. The regression
+is invisible under in-process test harnesses because pytest keeps the process
+alive long enough for the thread to complete.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+import pytest
+
+
+def _free_port() -> int:
+    """Return a free TCP port on 127.0.0.1."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _CapturingHandler(BaseHTTPRequestHandler):
+    """HTTP handler that captures POST bodies and serves /health."""
+
+    received: list[dict[str, Any]] = []
+
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length) if length else b""
+        try:
+            payload = json.loads(body)
+        except Exception:
+            payload = {}
+        self.__class__.received.append(payload)
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"latest_version":"99.99.99","source":"external"}')
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path.endswith("/health"):
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"status":"ok","version":"mock-1.0"}')
+            return
+        self.send_response(404)
+        self.end_headers()
+
+    def log_message(self, *_args: Any, **_kwargs: Any) -> None:  # silence default access logs
+        pass
+
+
+@pytest.fixture
+def mock_checkpoint() -> Any:
+    """Spin up a local HTTP server, yield (url, received_list), tear down after."""
+    _CapturingHandler.received = []
+    port = _free_port()
+    server = HTTPServer(("127.0.0.1", port), _CapturingHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{port}", _CapturingHandler.received
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_telemetry_flushes_on_immediate_exit(mock_checkpoint: Any) -> None:
+    """A Python subprocess that exits immediately after AxonFlow() init must
+    still deliver its telemetry ping to the checkpoint.
+
+    Without the atexit flush fix, the daemon thread is killed on interpreter
+    shutdown and the POST never completes — this test catches that regression.
+    """
+    base_url, received = mock_checkpoint
+
+    # Subprocess runs a one-liner that instantiates the client and exits.
+    # No sleep, no explicit flush — only the SDK's atexit handler should
+    # keep the ping alive until delivery.
+    env = os.environ.copy()
+    env.pop("DO_NOT_TRACK", None)  # autouse conftest fixture doesn't apply to subprocesses
+    env.pop("AXONFLOW_TELEMETRY", None)
+    env["AXONFLOW_CHECKPOINT_URL"] = f"{base_url}/v1/ping"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from axonflow import AxonFlow; AxonFlow(endpoint='"  # no trailing sleep
+            + base_url
+            + "')",
+        ],
+        env=env,
+        capture_output=True,
+        timeout=15,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+    # Give the OS a beat to flush the POST; the subprocess has already exited,
+    # so any delay here is pure arrival-on-socket slack.
+    deadline = time.time() + 5.0
+    while time.time() < deadline and not received:
+        time.sleep(0.05)
+
+    assert len(received) >= 1, (
+        "telemetry ping was not received by the mock checkpoint — "
+        "the atexit flush regression has returned. "
+        f"subprocess stderr: {result.stderr!r}"
+    )
+    payload = received[0]
+    assert payload.get("sdk") == "python"
+    assert payload.get("sdk_version")
+    assert payload.get("instance_id")


### PR DESCRIPTION
Closes getaxonflow/axonflow-enterprise#1692

## Summary

The SDK's telemetry thread was spawned as \`threading.Thread(daemon=True)\`, which is killed on interpreter shutdown. Short-lived processes (CLI one-liners, serverless handlers, quickstart snippets, cold-start functions) exit before the HTTP POST to checkpoint completes — silently dropping telemetry with no error visible to the caller.

## Investigation

Reproduced 2026-04-24 against a local mock checkpoint server:
- 5× \`python -c \"from axonflow import AxonFlow; AxonFlow(endpoint='http://127.0.0.1:9999')\"\` → **0/5 pings arrived**
- Same code + \`time.sleep(5)\` → **1/1 arrives**
- TypeScript SDK on identical setup → **5/5 arrives** (Node event loop refcounts pending fetches)

Full investigation: \`axonflow-business-docs/metrics/TELEMETRY_ADOPTION_BASELINE_2026-04-24.md\`.

## Fix

Register an \`atexit\` handler that joins the telemetry thread with a 3-second bounded timeout (matching the HTTP request timeout). Preserves fire-and-forget semantics for long-running processes; just keeps the interpreter alive long enough for the POST to complete when it's shutting down early.

## Regression test

New \`tests/test_telemetry_short_lived.py\` spins a local HTTP mock on a random free port, runs a **subprocess** that exits immediately after client init, and asserts the mock receives a ping. This is the invariant that catches the regression — an in-process pytest can't, because pytest keeps the interpreter alive long enough for the daemon thread to complete.

Verified:
- Test **FAILS** with the atexit hook removed (explicit error: \`telemetry ping was not received by the mock checkpoint — the atexit flush regression has returned\`)
- Test **PASSES** with the fix in place
- Full \`tests/test_telemetry*.py\` suite: 40/40 pass

## Impact

Closes one of three compounding silent-failure modes in the 2026-04-24 baseline. Separate tracks:
- axonflow-enterprise#1694 — Python 3.9 silent downgrade to v4.2.0
- (internal) v4.x localhost-suppression gate (only affects users on Python 3.9 who get v4.2.0)

## Post-merge

Bump to **v6.7.0** (minor, user-visible delivery reliability change), publish to PyPI, and add an entry to the post-fix telemetry baseline so we can measure actual adoption going forward.