### PR TITLE
docs: reorder v6.6.1 changelog — lead with user-facing fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Telemetry pings now deliver reliably from short-lived processes (CLI, serverless, cold-starts).
-- Telemetry path is bounded at `_TIMEOUT_SECONDS` (3s) total; the `/health` probe and checkpoint POST share a single deadline instead of stacking.
 - **Retire dead staging endpoint across the SDK.** The decommissioned
   `staging-eu.getaxonflow.com` host was still referenced in 11 places,
   including the public `AxonFlow.sandbox()` factory, every example's default
@@ -34,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     reference with the correct `AXONFLOW_CLIENT_ID` / `AXONFLOW_CLIENT_SECRET`
     variables, and lists the four example files that actually exist
     (previously referenced stale `basic_usage.py` and `interceptors.py`).
+- Telemetry pings now deliver reliably from short-lived processes (CLI, serverless, cold-starts).
+- Telemetry path is bounded at `_TIMEOUT_SECONDS` (3s) total; the `/health` probe and checkpoint POST share a single deadline instead of stacking.
 
 ## [6.6.0] - 2026-04-22
 


### PR DESCRIPTION
## Summary

Two-line reorder of the `[6.6.1]` section. The staging-endpoint retirement is what a Python user reading the changelog actually cares about (`AxonFlow.sandbox()` was pointing at a decommissioned host, examples defaulted there too). Moving it above the telemetry bullets so the headline matches the impact.

No text changes to the entries themselves.

## Diff

```
 ### Fixed

-- Telemetry pings now deliver reliably from short-lived processes ...
-- Telemetry path is bounded at `_TIMEOUT_SECONDS` (3s) total ...
 - **Retire dead staging endpoint across the SDK.** ...
   - `AxonFlow.sandbox()` ...
   - examples ...
   - SECURITY.md ...
   - CONTRIBUTING.md ...
+- Telemetry pings now deliver reliably from short-lived processes ...
+- Telemetry path is bounded at `_TIMEOUT_SECONDS` (3s) total ...
```

## Completeness check

Commits since `v6.6.0` and their disposition in the changelog:

| SHA | Type | In changelog? |
|---|---|---|
| `91a7591` | fix(telemetry) #147 | Yes — 2 terse bullets |
| `003f77e` | fix: retire dead staging #148 | Yes — led paragraph + 4 sub-bullets |
| `adfcd89` | ci: wire-shape CI #149 | No (internal, policy-correct) |
| `a080be3` | ci: harden wire-shape #150 | No (internal, policy-correct) |
| `8708836` | docs: promote Unreleased #151 | No (release-prep, not a fix) |

Nothing missing; no internal tooling bullets leaking in.

## Test plan

- [x] `awk -v ver=6.6.1 '$0 ~ "^## \\[\"ver\"\\]\"'` still extracts the section cleanly (release preflight)
- [ ] CI green