### PR TITLE
chore(release): promote to [6.6.2] — fix shipped __version__ runtime drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
      and tag v{X.Y.Z}. The release workflow's preflight checks the section
      header matches the tag. -->
 
+## [6.6.2] - 2026-04-25
+
+### Fixed
+
+- **Runtime `axonflow.__version__` correctly reports the installed version.**
+  Wheels for v6.6.1 shipped with `axonflow.__version__` stuck at `"6.6.0"`
+  because the release workflow was targeting the wrong file when bumping
+  the version constant (it was rewriting `axonflow/__init__.py`, but the
+  real constant lives in `axonflow/_version.py` and `__init__.py` only
+  re-exports from there). Package metadata read by `pip show` was correct,
+  so install/upgrade worked fine; the drift only affected code that read
+  `axonflow.__version__` at runtime (telemetry self-identification,
+  version-gated feature detection in user code, log output). No functional
+  changes — this release ships the same binary behavior as v6.6.1 with
+  the runtime version correctly set to `6.6.2`.
+
 ## [6.6.1] - 2026-04-24
 
 ### Fixed

--- a/axonflow/_version.py
+++ b/axonflow/_version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the AxonFlow SDK version."""
 
-__version__ = "6.6.1"
+__version__ = "6.6.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "axonflow"
-version = "6.6.1"
+version = "6.6.2"
 description = "AxonFlow Python SDK - Enterprise AI Governance in 3 Lines of Code"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

Patch release to fix a real bug in the shipped v6.6.1 wheel: `axonflow.__version__` at runtime returns `"6.6.0"` even though `pip show axonflow` correctly reports `6.6.1`.

Three changes:
- `CHANGELOG.md`: new `## [6.6.2] - 2026-04-25` section
- `pyproject.toml`: 6.6.1 → 6.6.2
- `axonflow/_version.py`: 6.6.1 → 6.6.2

All three move together so the `validate-version-alignment` gate stays green through the transition.

## Root cause (now fixed)

`release.yml` was running:

```bash
sed -i "s/^__version__ = .*/__version__ = \"${VERSION}\"/" axonflow/__init__.py
```

But `axonflow/__init__.py` only does `from axonflow._version import __version__`. The sed matched nothing and silently exited 0. The real `__version__` constant lives in `axonflow/_version.py` which was never touched during release. Result: every published wheel had `axonflow/_version.py` frozen at whatever value was on main *before* the tag was pushed.

Fix landed in #153 (merged earlier today) — release.yml now seds `_version.py` and asserts-post-sed so silent no-ops fail loudly. v6.6.2 is the first release to benefit from that fix.

## What v6.6.2 changes for users

**Functional behavior**: none. Same SDK as v6.6.1.

**Observable**: `axonflow.__version__` now correctly returns `"6.6.2"`. Affects:
- Telemetry self-reporting (your adoption metrics show accurate numbers)
- User code doing version-gated feature detection (`if axonflow.__version__ >= "6.6.1"`) — was broken on v6.6.1, works on v6.6.2
- Log output / bug reports that print SDK version

## Impact assessment on other SDKs

Full audit done before this PR. The bug is **Python-only** — it was specific to the two-file `_version.py` + `__init__.py` setup where release.yml was targeting the wrong file:

| SDK | Latest | Status |
|---|---|---|
| Python | 6.6.1 → 6.6.2 (this PR) | **was broken, being fixed** |
| Go | v5.6.1 | `version.go = 5.6.1` ✓ |
| TS | 5.6.0 | `package.json` + both `dist/*/version.js` all at 5.6.0 ✓ |
| Java | 5.7.0 | `pom.properties` in JAR reads 5.7.0 (consumed at runtime via `detectSdkVersion()`) ✓ |

## Release flow after merge

1. Merge this PR
2. Tag `v6.6.2`
3. `release.yml` preflight validates CHANGELOG section matches tag
4. Build + publish to PyPI via trusted publisher
5. Verify: `pip install axonflow==6.6.2 && python -c "import axonflow; print(axonflow.__version__)"` returns `"6.6.2"`

## Test plan

- [x] `validate-version-alignment.sh` passes locally
- [x] Release-workflow awk extracts `[6.6.2]` section cleanly
- [ ] CI green on this PR
- [ ] Post-publish: runtime `__version__` matches tag