### PR TITLE
feat(types): wire-shape alignment sweep (proper audit) — 36 → 26 drift entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
      and tag v{X.Y.Z}. The release workflow's preflight checks the section
      header matches the tag. -->
 
+## [Unreleased]
+
+### Added
+
+- **`WebhookSubscription.secret`** — HMAC-SHA256 signing key now exposed on the response from `create_webhook`. Required to verify the `X-AxonFlow-Signature` header on inbound webhook deliveries; without it, callers couldn't validate payload authenticity. Also adds `org_id` and `tenant_id` (ownership scoping).
+- **`StepGateRequest`** carries `tokens_in`, `tokens_out`, `cost_usd` so budget-based policies can evaluate gate-time cost estimates.
+- **`StepGateResponse.decision_id`** — unique audit correlator that links a gate response to its audit row.
+- **`ListWorkflowsResponse.limit` / `offset`** — pagination echo, surfaced on the response.
+- **`StaticPolicy.policy_id` / `priority`** — wire-canonical fields surfaced.
+- **`CreateStaticPolicyRequest.priority` / `tags`** and **`UpdateStaticPolicyRequest.priority` / `tags`** — match the spec.
+- **`UpdatePlanRequest.metadata`** — accept arbitrary plan metadata, opaque to the platform.
+- **`UsageBreakdownItem.group_by`** — dimension name (provider/model/agent/etc.) is now exposed on each item.
+- **`BudgetAlert.acknowledged`** — alert dismissal flag.
+- **`Budget.org_id` / `tenant_id`** — ownership scoping.
+- **`UsageRecord`** gains `created_at`, `success`, `error_message`, `latency_ms`, `team_id`, `tenant_id`, `user_id`, `workflow_id` to match the wire. Legacy `timestamp` field is `DEPRECATED` (orphan read; the wire emits `created_at`).
+- **`WorkflowStatusResponse.metadata`** — arbitrary workflow metadata.
+- **`CreateWorkflowResponse.started_at`** — wire-canonical timestamp. Legacy `created_at` and `source` are `DEPRECATED` (orphan reads on the create response).
+- **`ExecutionSnapshot.retry_count`** — number of retry attempts on a step.
+- **`Finding.article`** — regulatory article reference (e.g. MAS FEAT principle number).
+- **`PolicyOverride.id` / `enabled_override`** — wire-canonical fields. `active` is `DEPRECATED` (orphan read).
+- **`PolicyVersion.id` / `policy_id` / `change_summary` / `snapshot`** — match the wire shape (versions are immutable snapshots, not before/after diffs). `change_description`, `previous_values`, `new_values` are `DEPRECATED` orphan reads.
+- **`DynamicPolicyMatch.message`** — wire-canonical name. `reason` is `DEPRECATED` (orphan read).
+- **`ExfiltrationCheckInfo.exceeded` / `limit_type`** — match the wire. `within_limits` is `DEPRECATED`.
+- **`CancelPlanResponse.success`** — wire-canonical boolean. `message` is `DEPRECATED` (orphan read).
+- **`PlanResponse`** gains the wire top-level fields `success`, `version`, `result`, `error`, `workflow_execution_id`, `policy_info`.
+- **`ResumePlanResponse.result`** — final aggregated result (canonical wire field). Six fields (`workflow_id`, `message`, `step_result`, `next_step`, `next_step_name`, `total_steps`) are now `DEPRECATED` — none of them were populated by the resume decoder against the actual server response.
+- **`MCPCheckInputRequest.client_id` / `tenant_id` / `user_id` / `user_role` / `user_token`** and **`MCPCheckOutputRequest.client_id` / `tenant_id` / `user_id` / `user_token`** — match the spec scoping fields.
+
+### Notes
+
+The above is an audit-driven sweep against the wire-shape contract gate. All changes are additive (new fields default to `None`) or `DEPRECATED`-marked alias fields kept for compile-time compat. Removal scheduled for v7.
+
+The earlier overnight claim that "Python baseline is clean" was wrong — that was a key-name confusion (Python uses `per_model_drift`, the others use `per_type_drift`); a proper audit found 36 drift entries similar in pattern to the TS+Go SDK sweeps. After this sweep, 26 drift entries remain (mostly `DEPRECATED` aliases retained for source-compat + Cat C entries to file separately + Plugin Batch 1 SDK additions pending platform-side spec coverage).
+
+Two platform-side spec corrections filed alongside this work, for issues the audit surfaced where the spec was wrong (server emits the SDK's name): `AISystemRegistry.materiality_classification` (axonflow-enterprise#1708), `DynamicPolicyInfo` schema completely wrong shape (axonflow-enterprise#1709). No SDK change for those — the SDK is correct.
+
 ## [6.6.2] - 2026-04-25
 
 ### Fixed

--- a/axonflow/client.py
+++ b/axonflow/client.py
@@ -1335,6 +1335,12 @@ class AxonFlow:
         statement: str,
         operation: str = "execute",
         parameters: dict[str, Any] | None = None,
+        *,
+        client_id: str | None = None,
+        tenant_id: str | None = None,
+        user_id: str | None = None,
+        user_role: str | None = None,
+        user_token: str | None = None,
     ) -> MCPCheckInputResponse:
         """Validate an MCP request against configured policies without executing it.
 
@@ -1346,6 +1352,11 @@ class AxonFlow:
             statement: The SQL query or command to validate.
             operation: Operation type - "query" or "execute" (default).
             parameters: Optional query parameters.
+            client_id: Client identifier (overrides client config when set).
+            tenant_id: Tenant identifier for multi-tenant scoping.
+            user_id: End-user identifier for per-user policies.
+            user_role: User role for role-based policies.
+            user_token: User auth token for downstream propagation.
 
         Returns:
             MCPCheckInputResponse with allowed status, block reason, and policy info.
@@ -1361,6 +1372,17 @@ class AxonFlow:
         }
         if parameters:
             body["parameters"] = parameters
+        # Wire-canonical scoping fields surfaced in the v6 sweep.
+        if client_id is not None:
+            body["client_id"] = client_id
+        if tenant_id is not None:
+            body["tenant_id"] = tenant_id
+        if user_id is not None:
+            body["user_id"] = user_id
+        if user_role is not None:
+            body["user_role"] = user_role
+        if user_token is not None:
+            body["user_token"] = user_token
 
         if self._config.debug:
             self._logger.debug(
@@ -1395,6 +1417,11 @@ class AxonFlow:
         message: str | None = None,
         metadata: dict[str, Any] | None = None,
         row_count: int = 0,
+        *,
+        client_id: str | None = None,
+        tenant_id: str | None = None,
+        user_id: str | None = None,
+        user_token: str | None = None,
     ) -> MCPCheckOutputResponse:
         """Validate MCP response data against configured policies.
 
@@ -1407,6 +1434,10 @@ class AxonFlow:
             message: Execute-style response message (e.g., "5 rows affected").
             metadata: Connector metadata for SQLi scanning.
             row_count: Total number of rows returned.
+            client_id: Client identifier (overrides client config when set).
+            tenant_id: Tenant identifier for multi-tenant scoping.
+            user_id: End-user identifier for per-user policies.
+            user_token: User auth token for downstream propagation.
 
         Returns:
             MCPCheckOutputResponse with allowed status, redacted data, and policy info.
@@ -1426,6 +1457,15 @@ class AxonFlow:
             body["metadata"] = metadata
         if row_count > 0:
             body["row_count"] = row_count
+        # Wire-canonical scoping fields surfaced in the v6 sweep.
+        if client_id is not None:
+            body["client_id"] = client_id
+        if tenant_id is not None:
+            body["tenant_id"] = tenant_id
+        if user_id is not None:
+            body["user_id"] = user_id
+        if user_token is not None:
+            body["user_token"] = user_token
 
         if self._config.debug:
             self._logger.debug(
@@ -1530,19 +1570,32 @@ class AxonFlow:
         plan_id = response.plan_id or (
             response.data.get("plan_id", "") if isinstance(response.data, dict) else ""
         )
+        # Source the wire top-level fields (success / version / result /
+        # error / workflow_execution_id / policy_info) from the parsed
+        # ClientResponse + nested data dict. They appear at the top
+        # level on current platform builds; older nested-only builds
+        # used `data.*`, so fall back through both layers.
+        data_dict: dict[str, Any] = (
+            response.data if isinstance(response.data, dict) else {}
+        )
+        # `policy_info` on PlanResponse is the spec's PolicyEvaluationResult
+        # shape (different from ClientResponse.policy_info, which is
+        # PolicyEvaluationInfo). Source from the wire dict and let
+        # pydantic validate the shape.
+        wire_policy_info = data_dict.get("policy_info")
         return PlanResponse(
             plan_id=plan_id,
             steps=steps,
-            domain=response.data.get("domain", domain or "generic")
-            if response.data and isinstance(response.data, dict)
-            else (domain or "generic"),
-            complexity=response.data.get("complexity", 0)
-            if response.data and isinstance(response.data, dict)
-            else 0,
-            parallel=response.data.get("parallel", False)
-            if response.data and isinstance(response.data, dict)
-            else False,
+            domain=data_dict.get("domain", domain or "generic"),
+            complexity=data_dict.get("complexity", 0),
+            parallel=data_dict.get("parallel", False),
             metadata=response.metadata,
+            success=response.success,
+            version=data_dict.get("version"),
+            result=response.result or data_dict.get("result"),
+            error=response.error,
+            workflow_execution_id=data_dict.get("workflow_execution_id"),
+            policy_info=wire_policy_info if isinstance(wire_policy_info, dict) else None,
         )
 
     async def execute_plan(
@@ -1682,6 +1735,8 @@ class AxonFlow:
             json_data["execution_mode"] = request.execution_mode.value
         if request.domain is not None:
             json_data["domain"] = request.domain
+        if request.metadata is not None:
+            json_data["metadata"] = request.metadata
 
         response = await self._map_request(
             "PUT",
@@ -4045,13 +4100,25 @@ class AxonFlow:
             msg = "Unexpected response type from workflow creation"
             raise TypeError(msg)
 
+        # The wire emits `started_at` (canonical) — `created_at` is a
+        # legacy SDK field that has always read None. Read both for
+        # back-compat: prefer the canonical value, fall through to the
+        # legacy slot only if the server still emits it.
+        started_at_str = response.get("started_at") or response.get("created_at")
+        started_at = _parse_datetime(started_at_str) if started_at_str else None
+        # The wire shape doesn't include `source` on the create
+        # response; if a legacy server still sends it, surface it.
+        source_str = response.get("source")
         return CreateWorkflowResponse(
             workflow_id=response["workflow_id"],
             workflow_name=response["workflow_name"],
-            source=WorkflowSource(response["source"]),
             status=WorkflowStatus(response["status"]),
-            created_at=_parse_datetime(response["created_at"]),
+            started_at=started_at,
             trace_id=response.get("trace_id"),
+            # @deprecated aliases populated for source-compat with
+            # callers that read the legacy field names.
+            created_at=started_at,
+            source=WorkflowSource(source_str) if source_str else None,
         )
 
     async def get_workflow(self, workflow_id: str) -> WorkflowStatusResponse:
@@ -4139,6 +4206,13 @@ class AxonFlow:
             body["retry_policy"] = request.retry_policy.value
         if request.idempotency_key is not None:
             body["idempotency_key"] = request.idempotency_key
+        # Wire-canonical budget-hint fields surfaced in the v6 sweep.
+        if request.tokens_in is not None:
+            body["tokens_in"] = request.tokens_in
+        if request.tokens_out is not None:
+            body["tokens_out"] = request.tokens_out
+        if request.cost_usd is not None:
+            body["cost_usd"] = request.cost_usd
 
         if self._config.debug:
             self._logger.debug(
@@ -4169,6 +4243,7 @@ class AxonFlow:
             reason=response.get("reason"),
             policy_ids=response.get("policy_ids", []),
             approval_url=response.get("approval_url"),
+            decision_id=response.get("decision_id"),
             policies_evaluated=response.get("policies_evaluated"),
             policies_matched=response.get("policies_matched"),
             cached=response.get("cached", False),
@@ -4476,6 +4551,8 @@ class AxonFlow:
         return ListWorkflowsResponse(
             workflows=workflows,
             total=response.get("total", len(workflows)),
+            limit=response.get("limit"),
+            offset=response.get("offset"),
         )
 
     # =========================================================================
@@ -6048,6 +6125,7 @@ class AxonFlow:
                 _parse_datetime(data["completed_at"]) if data.get("completed_at") else None
             ),
             trace_id=data.get("trace_id"),
+            metadata=data.get("metadata"),
             steps=steps,
         )
 

--- a/axonflow/client.py
+++ b/axonflow/client.py
@@ -1575,9 +1575,7 @@ class AxonFlow:
         # ClientResponse + nested data dict. They appear at the top
         # level on current platform builds; older nested-only builds
         # used `data.*`, so fall back through both layers.
-        data_dict: dict[str, Any] = (
-            response.data if isinstance(response.data, dict) else {}
-        )
+        data_dict: dict[str, Any] = response.data if isinstance(response.data, dict) else {}
         # `policy_info` on PlanResponse is the spec's PolicyEvaluationResult
         # shape (different from ClientResponse.policy_info, which is
         # PolicyEvaluationInfo). Source from the wire dict and let

--- a/axonflow/client.py
+++ b/axonflow/client.py
@@ -1407,9 +1407,25 @@ class AxonFlow:
         statement: str,
         operation: str = "execute",
         parameters: dict[str, Any] | None = None,
+        *,
+        client_id: str | None = None,
+        tenant_id: str | None = None,
+        user_id: str | None = None,
+        user_role: str | None = None,
+        user_token: str | None = None,
     ) -> MCPCheckInputResponse:
         """Alias for :meth:`mcp_check_input`. Validates tool input against configured policies."""
-        return await self.mcp_check_input(connector_type, statement, operation, parameters)
+        return await self.mcp_check_input(
+            connector_type,
+            statement,
+            operation,
+            parameters,
+            client_id=client_id,
+            tenant_id=tenant_id,
+            user_id=user_id,
+            user_role=user_role,
+            user_token=user_token,
+        )
 
     async def mcp_check_output(
         self,
@@ -1491,10 +1507,23 @@ class AxonFlow:
         message: str | None = None,
         metadata: dict[str, Any] | None = None,
         row_count: int = 0,
+        *,
+        client_id: str | None = None,
+        tenant_id: str | None = None,
+        user_id: str | None = None,
+        user_token: str | None = None,
     ) -> MCPCheckOutputResponse:
         """Alias for :meth:`mcp_check_output`. Validates tool output against configured policies."""
         return await self.mcp_check_output(
-            connector_type, response_data, message, metadata, row_count
+            connector_type,
+            response_data,
+            message,
+            metadata,
+            row_count,
+            client_id=client_id,
+            tenant_id=tenant_id,
+            user_id=user_id,
+            user_token=user_token,
         )
 
     async def generate_plan(
@@ -1587,6 +1616,10 @@ class AxonFlow:
             if isinstance(wire_policy_info_raw, dict)
             else None
         )
+        # Use `is not None` rather than `or` to fall through — `or` would
+        # falsey-clobber legitimate empty results (0, False, "", [], {})
+        # with the data_dict fallback.
+        result_value = response.result if response.result is not None else data_dict.get("result")
         return PlanResponse(
             plan_id=plan_id,
             steps=steps,
@@ -1596,7 +1629,7 @@ class AxonFlow:
             metadata=response.metadata,
             success=response.success,
             version=data_dict.get("version"),
-            result=response.result or data_dict.get("result"),
+            result=result_value,
             error=response.error,
             workflow_execution_id=data_dict.get("workflow_execution_id"),
             policy_info=policy_info_typed,
@@ -4107,9 +4140,13 @@ class AxonFlow:
         # The wire emits `started_at` (canonical) — `created_at` is a
         # legacy SDK field that has always read None. Read both for
         # back-compat: prefer the canonical value, fall through to the
-        # legacy slot only if the server still emits it.
-        started_at_str = response.get("started_at") or response.get("created_at")
-        started_at = _parse_datetime(started_at_str) if started_at_str else None
+        # legacy slot only if the canonical key is missing entirely.
+        # `is not None` (not `or`) so an empty string from a buggy
+        # server doesn't silently swap to the legacy slot.
+        started_at_raw = response.get("started_at")
+        if started_at_raw is None:
+            started_at_raw = response.get("created_at")
+        started_at = _parse_datetime(started_at_raw) if started_at_raw else None
         # The wire shape doesn't include `source` on the create
         # response; if a legacy server still sends it, surface it.
         source_str = response.get("source")
@@ -6934,10 +6971,26 @@ class SyncAxonFlow:
         statement: str,
         operation: str = "execute",
         parameters: dict[str, Any] | None = None,
+        *,
+        client_id: str | None = None,
+        tenant_id: str | None = None,
+        user_id: str | None = None,
+        user_role: str | None = None,
+        user_token: str | None = None,
     ) -> MCPCheckInputResponse:
         """Validate an MCP request against configured policies without executing it."""
         return self._run_sync(
-            self._async_client.mcp_check_input(connector_type, statement, operation, parameters)
+            self._async_client.mcp_check_input(
+                connector_type,
+                statement,
+                operation,
+                parameters,
+                client_id=client_id,
+                tenant_id=tenant_id,
+                user_id=user_id,
+                user_role=user_role,
+                user_token=user_token,
+            )
         )
 
     def mcp_check_output(
@@ -6947,11 +7000,24 @@ class SyncAxonFlow:
         message: str | None = None,
         metadata: dict[str, Any] | None = None,
         row_count: int = 0,
+        *,
+        client_id: str | None = None,
+        tenant_id: str | None = None,
+        user_id: str | None = None,
+        user_token: str | None = None,
     ) -> MCPCheckOutputResponse:
         """Validate MCP response data against configured policies."""
         return self._run_sync(
             self._async_client.mcp_check_output(
-                connector_type, response_data, message, metadata, row_count
+                connector_type,
+                response_data,
+                message,
+                metadata,
+                row_count,
+                client_id=client_id,
+                tenant_id=tenant_id,
+                user_id=user_id,
+                user_token=user_token,
             )
         )
 
@@ -6961,10 +7027,26 @@ class SyncAxonFlow:
         statement: str,
         operation: str = "execute",
         parameters: dict[str, Any] | None = None,
+        *,
+        client_id: str | None = None,
+        tenant_id: str | None = None,
+        user_id: str | None = None,
+        user_role: str | None = None,
+        user_token: str | None = None,
     ) -> MCPCheckInputResponse:
         """Alias for :meth:`mcp_check_input`. Validates tool input against configured policies."""
         return self._run_sync(
-            self._async_client.mcp_check_input(connector_type, statement, operation, parameters)
+            self._async_client.mcp_check_input(
+                connector_type,
+                statement,
+                operation,
+                parameters,
+                client_id=client_id,
+                tenant_id=tenant_id,
+                user_id=user_id,
+                user_role=user_role,
+                user_token=user_token,
+            )
         )
 
     def check_tool_output(
@@ -6974,11 +7056,24 @@ class SyncAxonFlow:
         message: str | None = None,
         metadata: dict[str, Any] | None = None,
         row_count: int = 0,
+        *,
+        client_id: str | None = None,
+        tenant_id: str | None = None,
+        user_id: str | None = None,
+        user_token: str | None = None,
     ) -> MCPCheckOutputResponse:
         """Alias for :meth:`mcp_check_output`. Validates tool output against configured policies."""
         return self._run_sync(
             self._async_client.mcp_check_output(
-                connector_type, response_data, message, metadata, row_count
+                connector_type,
+                response_data,
+                message,
+                metadata,
+                row_count,
+                client_id=client_id,
+                tenant_id=tenant_id,
+                user_id=user_id,
+                user_token=user_token,
             )
         )
 

--- a/axonflow/client.py
+++ b/axonflow/client.py
@@ -179,6 +179,7 @@ from axonflow.types import (
     PlanVersionsResponse,
     PolicyApprovalResult,
     PolicyConflictResponse,
+    PolicyEvaluationResult,
     PricingInfo,
     PricingListResponse,
     RateLimitInfo,
@@ -1578,9 +1579,14 @@ class AxonFlow:
         data_dict: dict[str, Any] = response.data if isinstance(response.data, dict) else {}
         # `policy_info` on PlanResponse is the spec's PolicyEvaluationResult
         # shape (different from ClientResponse.policy_info, which is
-        # PolicyEvaluationInfo). Source from the wire dict and let
-        # pydantic validate the shape.
-        wire_policy_info = data_dict.get("policy_info")
+        # PolicyEvaluationInfo). Source from the wire dict and validate
+        # against the typed model so callers see the right shape.
+        wire_policy_info_raw = data_dict.get("policy_info")
+        policy_info_typed: PolicyEvaluationResult | None = (
+            PolicyEvaluationResult.model_validate(wire_policy_info_raw)
+            if isinstance(wire_policy_info_raw, dict)
+            else None
+        )
         return PlanResponse(
             plan_id=plan_id,
             steps=steps,
@@ -1593,7 +1599,7 @@ class AxonFlow:
             result=response.result or data_dict.get("result"),
             error=response.error,
             workflow_execution_id=data_dict.get("workflow_execution_id"),
-            policy_info=wire_policy_info if isinstance(wire_policy_info, dict) else None,
+            policy_info=policy_info_typed,
         )
 
     async def execute_plan(

--- a/axonflow/masfeat.py
+++ b/axonflow/masfeat.py
@@ -122,6 +122,7 @@ class Finding:
     description: str
     status: FindingStatus
     remediation: str | None = None
+    article: str | None = None  # Regulatory article reference (e.g. MAS FEAT principle number).
     due_date: datetime | None = None
 
 

--- a/axonflow/policies.py
+++ b/axonflow/policies.py
@@ -113,13 +113,26 @@ class PolicySeverity(str, Enum):
 class PolicyOverride(BaseModel):
     """Policy override configuration."""
 
+    id: str | None = Field(
+        default=None, description="Override identifier (required to revoke a specific override)."
+    )
     policy_id: str
     action_override: OverrideAction
     override_reason: str
     created_by: str | None = None
     created_at: datetime
     expires_at: datetime | None = None
-    active: bool = True
+    enabled_override: bool | None = Field(
+        default=None,
+        description="Override enabled status — canonical wire field.",
+    )
+    active: bool = Field(
+        default=True,
+        description=(
+            "DEPRECATED: the wire emits `enabled_override`, not `active`. "
+            "Use `enabled_override`. Removed in v7."
+        ),
+    )
 
 
 class StaticPolicy(BaseModel):
@@ -128,6 +141,13 @@ class StaticPolicy(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     id: str
+    policy_id: str | None = Field(
+        default=None,
+        description=(
+            "Human-readable policy identifier (e.g. `sys_sqli_union_select`). "
+            "Distinct from `id` (the UUID)."
+        ),
+    )
     name: str
     description: str | None = None
     category: PolicyCategory
@@ -136,6 +156,9 @@ class StaticPolicy(BaseModel):
     severity: PolicySeverity = PolicySeverity.MEDIUM
     enabled: bool = True
     action: PolicyAction = PolicyAction.BLOCK
+    priority: int | None = Field(
+        default=None, description="Evaluation order — lower values run first."
+    )
     organization_id: str | None = Field(default=None, alias="organizationId")
     tenant_id: str | None = Field(default=None, alias="tenantId")
     created_at: datetime = Field(..., alias="createdAt")
@@ -178,6 +201,12 @@ class CreateStaticPolicyRequest(BaseModel):
     severity: PolicySeverity = PolicySeverity.MEDIUM
     enabled: bool = True
     action: PolicyAction = PolicyAction.BLOCK
+    priority: int | None = Field(
+        default=None, description="Evaluation order — lower values run first."
+    )
+    tags: list[str] | None = Field(
+        default=None, description="Free-form tags for grouping and filtering."
+    )
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -192,6 +221,8 @@ class UpdateStaticPolicyRequest(BaseModel):
     severity: PolicySeverity | None = None
     enabled: bool | None = None
     action: PolicyAction | None = None
+    priority: int | None = Field(default=None, description="Updated evaluation priority.")
+    tags: list[str] | None = Field(default=None, description="Updated tag set.")
 
 
 class CreatePolicyOverrideRequest(BaseModel):
@@ -346,17 +377,47 @@ class TestPatternResult(BaseModel):
 
 
 class PolicyVersion(BaseModel):
-    """Policy version history entry."""
+    """Policy version history entry.
+
+    The wire shape is an immutable snapshot, not a before/after diff.
+    The legacy ``changeDescription``, ``previousValues``, ``newValues``
+    aliases are kept for source-compat but the server actually emits
+    ``change_summary`` and a single ``snapshot`` object. Use those.
+    """
 
     model_config = ConfigDict(populate_by_name=True)
 
+    id: str | None = Field(default=None, description="Snapshot identifier (UUID).")
+    policy_id: str | None = Field(default=None, description="Policy this snapshot belongs to.")
     version: int
     changed_by: str | None = Field(default=None, alias="changedBy")
     changed_at: datetime = Field(..., alias="changedAt")
     change_type: str = Field(..., alias="changeType")
-    change_description: str | None = Field(default=None, alias="changeDescription")
-    previous_values: dict[str, Any] | None = Field(default=None, alias="previousValues")
-    new_values: dict[str, Any] | None = Field(default=None, alias="newValues")
+    change_summary: str | None = Field(
+        default=None, description="Summary of the change (canonical wire field)."
+    )
+    snapshot: dict[str, Any] | None = Field(
+        default=None, description="Complete policy state at this version (canonical wire field)."
+    )
+    change_description: str | None = Field(
+        default=None,
+        alias="changeDescription",
+        description=(
+            "DEPRECATED: the wire field is `change_summary`. Always reads None. Removed in v7."
+        ),
+    )
+    previous_values: dict[str, Any] | None = Field(
+        default=None,
+        alias="previousValues",
+        description=(
+            "DEPRECATED: the wire emits a single `snapshot`, not before/after diffs. Removed in v7."
+        ),
+    )
+    new_values: dict[str, Any] | None = Field(
+        default=None,
+        alias="newValues",
+        description="DEPRECATED: same as `previous_values`. Use `snapshot`. Removed in v7.",
+    )
 
 
 # ============================================================================

--- a/axonflow/types.py
+++ b/axonflow/types.py
@@ -310,7 +310,8 @@ class DynamicPolicyMatch(BaseModel):
     )
     action: str = Field(default="", description="Action taken (allow, block, log, etc.)")
     message: str | None = Field(
-        default=None, description="Optional message from the policy evaluation (canonical wire field)."
+        default=None,
+        description="Optional message from the policy evaluation (canonical wire field).",
     )
     reason: str | None = Field(
         default=None,

--- a/axonflow/types.py
+++ b/axonflow/types.py
@@ -316,8 +316,7 @@ class DynamicPolicyMatch(BaseModel):
     reason: str | None = Field(
         default=None,
         description=(
-            "DEPRECATED: the wire field is `message`, not `reason`. Use `message`. "
-            "Removed in v7."
+            "DEPRECATED: the wire field is `message`, not `reason`. Use `message`. Removed in v7."
         ),
     )
 
@@ -470,9 +469,7 @@ class PlanResponse(BaseModel):
     result: Any | None = Field(
         default=None, description="Final aggregated result if the plan executed inline."
     )
-    error: str | None = Field(
-        default=None, description="Error message if creation failed."
-    )
+    error: str | None = Field(default=None, description="Error message if creation failed.")
     workflow_execution_id: str | None = Field(
         default=None, description="Workflow execution ID if the plan was auto-executed."
     )
@@ -1130,9 +1127,7 @@ class UsageRecord(BaseModel):
     error_message: str | None = Field(
         default=None, description="Failure reason when success is False."
     )
-    latency_ms: int | None = Field(
-        default=None, description="Request latency in milliseconds."
-    )
+    latency_ms: int | None = Field(default=None, description="Request latency in milliseconds.")
     team_id: str | None = Field(default=None, description="Team scope.")
     tenant_id: str | None = Field(default=None, description="Tenant that owns this record.")
     user_id: str | None = Field(default=None, description="User that initiated the request.")
@@ -1204,9 +1199,7 @@ class WebhookSubscription(BaseModel):
     events: list[str] = Field(default_factory=list, description="Events to subscribe to")
     active: bool = Field(default=True, description="Whether the webhook is active")
     tenant_id: str | None = Field(default=None, description="Tenant that owns this subscription")
-    org_id: str | None = Field(
-        default=None, description="Organization that owns this subscription"
-    )
+    org_id: str | None = Field(default=None, description="Organization that owns this subscription")
     secret: str | None = Field(
         default=None,
         description=(

--- a/axonflow/types.py
+++ b/axonflow/types.py
@@ -282,7 +282,21 @@ class ExfiltrationCheckInfo(BaseModel):
     row_limit: int = Field(default=0, ge=0, description="Configured max rows per query")
     bytes_returned: int = Field(default=0, ge=0, description="Size of response data in bytes")
     byte_limit: int = Field(default=0, ge=0, description="Configured max bytes per response")
-    within_limits: bool = Field(default=True, description="Whether response is within limits")
+    exceeded: bool | None = Field(
+        default=None,
+        description="Whether any exfiltration limit was exceeded (canonical wire field).",
+    )
+    limit_type: str | None = Field(
+        default=None,
+        description='Type of limit that was exceeded ("rows", "bytes", "none").',
+    )
+    within_limits: bool = Field(
+        default=True,
+        description=(
+            "DEPRECATED: the wire emits `exceeded` + `limit_type`, not `within_limits`. "
+            "Use those instead. Removed in v7."
+        ),
+    )
 
 
 class DynamicPolicyMatch(BaseModel):
@@ -295,7 +309,16 @@ class DynamicPolicyMatch(BaseModel):
         description="Type of policy (rate-limit, budget, time-access, role-access, mcp, connector)",
     )
     action: str = Field(default="", description="Action taken (allow, block, log, etc.)")
-    reason: str | None = Field(default=None, description="Context for the policy match")
+    message: str | None = Field(
+        default=None, description="Optional message from the policy evaluation (canonical wire field)."
+    )
+    reason: str | None = Field(
+        default=None,
+        description=(
+            "DEPRECATED: the wire field is `message`, not `reason`. Use `message`. "
+            "Removed in v7."
+        ),
+    )
 
 
 class DynamicPolicyInfo(BaseModel):
@@ -371,6 +394,13 @@ class MCPCheckInputRequest(BaseModel):
     statement: str
     parameters: dict[str, Any] | None = Field(default=None)
     operation: str = Field(default="execute")
+    client_id: str | None = Field(default=None, description="Client identifier for scoping.")
+    tenant_id: str | None = Field(default=None, description="Tenant identifier for scoping.")
+    user_id: str | None = Field(default=None, description="User identifier for per-user policies.")
+    user_role: str | None = Field(default=None, description="User role for role-based policies.")
+    user_token: str | None = Field(
+        default=None, description="User token for downstream auth propagation."
+    )
 
 
 class MCPCheckInputResponse(BaseModel):
@@ -390,6 +420,12 @@ class MCPCheckOutputRequest(BaseModel):
     message: str | None = Field(default=None)
     metadata: dict[str, Any] | None = Field(default=None)
     row_count: int = Field(default=0, ge=0)
+    client_id: str | None = Field(default=None, description="Client identifier for scoping.")
+    tenant_id: str | None = Field(default=None, description="Tenant identifier for scoping.")
+    user_id: str | None = Field(default=None, description="User identifier for per-user policies.")
+    user_token: str | None = Field(
+        default=None, description="User token for downstream auth propagation."
+    )
 
 
 class MCPCheckOutputResponse(BaseModel):
@@ -425,6 +461,23 @@ class PlanResponse(BaseModel):
     complexity: int = 0
     parallel: bool = False
     metadata: dict[str, Any] = Field(default_factory=dict)
+    success: bool | None = Field(
+        default=None,
+        description="Whether the plan was created successfully (wire top-level field).",
+    )
+    version: int | None = Field(default=None, description="Plan version for optimistic locking.")
+    result: Any | None = Field(
+        default=None, description="Final aggregated result if the plan executed inline."
+    )
+    error: str | None = Field(
+        default=None, description="Error message if creation failed."
+    )
+    workflow_execution_id: str | None = Field(
+        default=None, description="Workflow execution ID if the plan was auto-executed."
+    )
+    policy_info: PolicyEvaluationResult | None = Field(
+        default=None, description="Policy evaluation summary for this plan creation."
+    )
 
 
 class PolicyEvaluationResult(BaseModel):
@@ -482,11 +535,25 @@ class ExecutionMode(str, Enum):
 
 
 class CancelPlanResponse(BaseModel):
-    """Response from cancelling a running plan."""
+    """Response from cancelling a running plan.
+
+    The wire shape is ``{success, plan_id, status}``. The legacy
+    ``message`` field reads ``data.message`` which the server doesn't
+    emit; use ``success`` and the ``status`` enum to detect outcome.
+    """
 
     plan_id: str = Field(..., description="ID of the cancelled plan")
     status: str = Field(..., description="Plan status after cancellation")
-    message: str = Field(..., description="Cancellation confirmation message")
+    success: bool | None = Field(
+        default=None, description="Whether the cancel succeeded (canonical wire field)."
+    )
+    message: str | None = Field(
+        default=None,
+        description=(
+            "DEPRECATED: the wire emits success+status, not message. "
+            "This field has always read None against JSON-decoded responses. Removed in v7."
+        ),
+    )
 
 
 class UpdatePlanRequest(BaseModel):
@@ -507,6 +574,9 @@ class UpdatePlanRequest(BaseModel):
         default=None, description="New execution mode for the plan"
     )
     domain: str | None = Field(default=None, description="New domain for the plan")
+    metadata: dict[str, object] | None = Field(
+        default=None, description="Arbitrary plan metadata, opaque to the platform."
+    )
 
 
 class UpdatePlanResponse(BaseModel):
@@ -544,17 +614,45 @@ class PlanVersionsResponse(BaseModel):
 
 
 class ResumePlanResponse(BaseModel):
-    """Response from resuming a paused plan."""
+    """Response from resuming a paused plan.
+
+    Wire shape: ``{plan_id, status, result}``. The
+    workflow_id/approved/message/step_result/next_step/next_step_name/
+    total_steps fields are kept for source-compat — none of them are
+    populated by the resume decoder against the actual server
+    response. New code should read ``result``.
+    """
 
     plan_id: str = Field(..., description="ID of the resumed plan")
-    workflow_id: str | None = Field(default=None, description="WCP workflow ID")
     status: str = Field(..., description="Plan status after resume")
+    result: Any | None = Field(
+        default=None,
+        description="Final aggregated result if the resume completed (canonical wire field).",
+    )
     approved: bool | None = Field(default=None, description="Whether the resume was approved")
-    message: str | None = Field(default=None, description="Resume confirmation message")
-    step_result: dict[str, Any] | None = Field(default=None, description="Result of executed step")
-    next_step: int | None = Field(default=None, description="Next step index")
-    next_step_name: str | None = Field(default=None, description="Next step name")
-    total_steps: int | None = Field(default=None, description="Total number of steps")
+    workflow_id: str | None = Field(
+        default=None,
+        description="DEPRECATED: never populated by the transformer. Removed in v7.",
+    )
+    message: str | None = Field(
+        default=None,
+        description=(
+            "DEPRECATED: the wire emits result, not message. Always read None. Removed in v7."
+        ),
+    )
+    step_result: dict[str, Any] | None = Field(
+        default=None,
+        description="DEPRECATED: never populated; use `result`. Removed in v7.",
+    )
+    next_step: int | None = Field(
+        default=None, description="DEPRECATED: not on the wire. Removed in v7."
+    )
+    next_step_name: str | None = Field(
+        default=None, description="DEPRECATED: not on the wire. Removed in v7."
+    )
+    total_steps: int | None = Field(
+        default=None, description="DEPRECATED: not on the wire. Removed in v7."
+    )
 
 
 # Gateway Mode Types
@@ -760,6 +858,9 @@ class ExecutionSnapshot(BaseModel):
     approval_required: bool = Field(default=False, description="Whether approval was required")
     approved_by: str = Field(default="", description="Approver ID")
     approved_at: str = Field(default="", description="Approval timestamp")
+    retry_count: int | None = Field(
+        default=None, description="Number of retry attempts on this step."
+    )
 
 
 class TimelineEntry(BaseModel):
@@ -892,6 +993,8 @@ class Budget(BaseModel):
     alert_thresholds: list[int] = Field(default_factory=list, description="Alert thresholds")
     enabled: bool = Field(default=True, description="Whether budget is enabled")
     scope_id: str | None = Field(default=None, description="Scope entity ID")
+    tenant_id: str | None = Field(default=None, description="Tenant that owns this budget.")
+    org_id: str | None = Field(default=None, description="Organization that owns this budget.")
     created_at: str | None = Field(default=None, description="Created timestamp")
     updated_at: str | None = Field(default=None, description="Updated timestamp")
 
@@ -927,6 +1030,9 @@ class BudgetAlert(BaseModel):
     amount_usd: float = Field(..., description="Amount when alert triggered")
     message: str = Field(..., description="Alert message")
     created_at: str = Field(..., description="Alert timestamp")
+    acknowledged: bool | None = Field(
+        default=None, description="Whether the alert has been dismissed by an operator."
+    )
 
 
 class BudgetAlertsResponse(BaseModel):
@@ -971,6 +1077,9 @@ class UsageSummary(BaseModel):
 class UsageBreakdownItem(BaseModel):
     """An item in a usage breakdown."""
 
+    group_by: str | None = Field(
+        default=None, description="Dimension name (provider, model, agent, etc.)"
+    )
     group_value: str = Field(..., description="Group dimension value")
     cost_usd: float = Field(default=0.0, ge=0, description="Cost in USD")
     percentage: float = Field(default=0.0, ge=0, description="Percentage of total")
@@ -1011,7 +1120,32 @@ class UsageRecord(BaseModel):
     request_id: str | None = Field(default=None, description="Request ID")
     org_id: str | None = Field(default=None, description="Organization ID")
     agent_id: str | None = Field(default=None, description="Agent ID")
-    timestamp: str | None = Field(default=None, description="Record timestamp")
+    created_at: str | None = Field(
+        default=None, description="When the record was created (canonical wire field)."
+    )
+    success: bool | None = Field(
+        default=None, description="Whether the underlying request succeeded."
+    )
+    error_message: str | None = Field(
+        default=None, description="Failure reason when success is False."
+    )
+    latency_ms: int | None = Field(
+        default=None, description="Request latency in milliseconds."
+    )
+    team_id: str | None = Field(default=None, description="Team scope.")
+    tenant_id: str | None = Field(default=None, description="Tenant that owns this record.")
+    user_id: str | None = Field(default=None, description="User that initiated the request.")
+    workflow_id: str | None = Field(
+        default=None, description="Workflow ID if this came from a workflow execution."
+    )
+    timestamp: str | None = Field(
+        default=None,
+        description=(
+            "DEPRECATED: the wire emits `created_at`, not `timestamp`. "
+            "This field has always read None against JSON-decoded responses. "
+            "Use `created_at`. Removed in v7."
+        ),
+    )
 
 
 class UsageRecordsResponse(BaseModel):
@@ -1068,6 +1202,18 @@ class WebhookSubscription(BaseModel):
     url: str = Field(..., description="Webhook URL")
     events: list[str] = Field(default_factory=list, description="Events to subscribe to")
     active: bool = Field(default=True, description="Whether the webhook is active")
+    tenant_id: str | None = Field(default=None, description="Tenant that owns this subscription")
+    org_id: str | None = Field(
+        default=None, description="Organization that owns this subscription"
+    )
+    secret: str | None = Field(
+        default=None,
+        description=(
+            "HMAC-SHA256 signing key for verifying inbound webhook payload signatures "
+            "(X-AxonFlow-Signature header). Returned by `create_webhook` on initial "
+            "creation; required for callers to validate payload authenticity."
+        ),
+    )
     created_at: str = Field(..., description="When the webhook was created")
     updated_at: str = Field(..., description="When the webhook was last updated")
 

--- a/axonflow/workflow.py
+++ b/axonflow/workflow.py
@@ -267,7 +267,10 @@ class StepGateResponse(BaseModel):
     )
     decision_id: str | None = Field(
         default=None,
-        description="Unique decision identifier for auditing (links a gate response to its audit row).",
+        description=(
+            "Unique decision identifier for auditing "
+            "(links a gate response to its audit row)."
+        ),
     )
     policies_evaluated: list[PolicyMatch] | None = Field(
         default=None,

--- a/axonflow/workflow.py
+++ b/axonflow/workflow.py
@@ -268,8 +268,7 @@ class StepGateResponse(BaseModel):
     decision_id: str | None = Field(
         default=None,
         description=(
-            "Unique decision identifier for auditing "
-            "(links a gate response to its audit row)."
+            "Unique decision identifier for auditing (links a gate response to its audit row)."
         ),
     )
     policies_evaluated: list[PolicyMatch] | None = Field(

--- a/axonflow/workflow.py
+++ b/axonflow/workflow.py
@@ -85,14 +85,37 @@ class CreateWorkflowRequest(BaseModel):
 
 
 class CreateWorkflowResponse(BaseModel):
-    """Response from creating a workflow."""
+    """Response from creating a workflow.
+
+    Wire shape: ``{workflow_id, workflow_name, status, started_at, trace_id}``.
+    The legacy ``source`` and ``created_at`` fields are kept for source-compat
+    only — the wire emits ``started_at`` (not ``created_at``) and does not
+    include ``source`` on the create response.
+    """
 
     workflow_id: str = Field(..., description="Unique identifier for the workflow")
     workflow_name: str = Field(..., description="Name of the workflow")
-    source: WorkflowSource = Field(..., description="Source orchestrator")
     status: WorkflowStatus = Field(..., description="Current status (always 'in_progress' for new)")
-    created_at: datetime = Field(..., description="When the workflow was created")
+    started_at: datetime | None = Field(
+        default=None,
+        description="When the workflow started executing (canonical wire field).",
+    )
     trace_id: str | None = None
+    created_at: datetime | None = Field(
+        default=None,
+        description=(
+            "DEPRECATED: the wire emits `started_at`, not `created_at`. "
+            "Always read None against JSON-decoded responses. Use `started_at`. "
+            "Removed in v7."
+        ),
+    )
+    source: WorkflowSource | None = Field(
+        default=None,
+        description=(
+            "DEPRECATED: not emitted on the create response. Read `source` from a "
+            "subsequent `get_workflow()` call instead. Removed in v7."
+        ),
+    )
 
 
 class ToolContext(BaseModel):
@@ -215,6 +238,15 @@ class StepGateRequest(BaseModel):
             "retry_context.idempotency_key."
         ),
     )
+    tokens_in: int | None = Field(
+        default=None, description="Estimated input tokens for this step (used by budget policies)."
+    )
+    tokens_out: int | None = Field(
+        default=None, description="Estimated output tokens for this step (used by budget policies)."
+    )
+    cost_usd: float | None = Field(
+        default=None, description="Estimated cost in USD for this step (used by budget policies)."
+    )
 
 
 class StepGateResponse(BaseModel):
@@ -232,6 +264,10 @@ class StepGateResponse(BaseModel):
     )
     approval_url: str | None = Field(
         default=None, description="URL to the approval portal (if decision is require_approval)"
+    )
+    decision_id: str | None = Field(
+        default=None,
+        description="Unique decision identifier for auditing (links a gate response to its audit row).",
     )
     policies_evaluated: list[PolicyMatch] | None = Field(
         default=None,
@@ -348,6 +384,9 @@ class WorkflowStatusResponse(BaseModel):
         default_factory=list, description="List of steps in the workflow"
     )
     trace_id: str | None = None
+    metadata: dict[str, object] | None = Field(
+        default=None, description="Arbitrary workflow metadata, opaque to the platform."
+    )
 
     def is_terminal(self) -> bool:
         """Check if the workflow is in a terminal state (completed, aborted, or failed)."""
@@ -373,6 +412,12 @@ class ListWorkflowsResponse(BaseModel):
         default_factory=list, description="List of workflows"
     )
     total: int = Field(default=0, ge=0, description="Total count (for pagination)")
+    limit: int | None = Field(
+        default=None, description="Echo of the limit query parameter (for pagination clients)."
+    )
+    offset: int | None = Field(
+        default=None, description="Echo of the offset query parameter (for pagination clients)."
+    )
 
 
 class MarkStepCompletedRequest(BaseModel):

--- a/tests/fixtures/wire_shape_baseline.json
+++ b/tests/fixtures/wire_shape_baseline.json
@@ -200,24 +200,13 @@
       "sdk_only": [
         "enabled"
       ],
-      "spec_only": [
-        "org_id",
-        "tenant_id"
-      ]
-    },
-    "BudgetAlert": {
-      "sdk_only": [],
-      "spec_only": [
-        "acknowledged"
-      ]
+      "spec_only": []
     },
     "CancelPlanResponse": {
       "sdk_only": [
         "message"
       ],
-      "spec_only": [
-        "success"
-      ]
+      "spec_only": []
     },
     "ClientRequest": {
       "sdk_only": [
@@ -238,19 +227,14 @@
       "sdk_only": [
         "organization_id"
       ],
-      "spec_only": [
-        "priority",
-        "tags"
-      ]
+      "spec_only": []
     },
     "CreateWorkflowResponse": {
       "sdk_only": [
         "created_at",
         "source"
       ],
-      "spec_only": [
-        "started_at"
-      ]
+      "spec_only": []
     },
     "DynamicPolicy": {
       "sdk_only": [
@@ -285,9 +269,7 @@
       "sdk_only": [
         "reason"
       ],
-      "spec_only": [
-        "message"
-      ]
+      "spec_only": []
     },
     "ExecutionSnapshot": {
       "sdk_only": [
@@ -295,9 +277,7 @@
         "approved_at",
         "approved_by"
       ],
-      "spec_only": [
-        "retry_count"
-      ]
+      "spec_only": []
     },
     "ExecutionSummary": {
       "sdk_only": [
@@ -310,36 +290,7 @@
       "sdk_only": [
         "within_limits"
       ],
-      "spec_only": [
-        "exceeded",
-        "limit_type"
-      ]
-    },
-    "ListWorkflowsResponse": {
-      "sdk_only": [],
-      "spec_only": [
-        "limit",
-        "offset"
-      ]
-    },
-    "MCPCheckInputRequest": {
-      "sdk_only": [],
-      "spec_only": [
-        "client_id",
-        "tenant_id",
-        "user_id",
-        "user_role",
-        "user_token"
-      ]
-    },
-    "MCPCheckOutputRequest": {
-      "sdk_only": [],
-      "spec_only": [
-        "client_id",
-        "tenant_id",
-        "user_id",
-        "user_token"
-      ]
+      "spec_only": []
     },
     "MarkStepCompletedRequest": {
       "sdk_only": [
@@ -354,14 +305,7 @@
         "parallel",
         "status"
       ],
-      "spec_only": [
-        "error",
-        "policy_info",
-        "result",
-        "success",
-        "version",
-        "workflow_execution_id"
-      ]
+      "spec_only": []
     },
     "PolicyEvaluationInfo": {
       "sdk_only": [
@@ -373,10 +317,7 @@
       "sdk_only": [
         "active"
       ],
-      "spec_only": [
-        "enabled_override",
-        "id"
-      ]
+      "spec_only": []
     },
     "PolicyVersion": {
       "sdk_only": [
@@ -388,13 +329,9 @@
         "previousValues"
       ],
       "spec_only": [
-        "change_summary",
         "change_type",
         "changed_at",
-        "changed_by",
-        "id",
-        "policy_id",
-        "snapshot"
+        "changed_by"
       ]
     },
     "ResumePlanResponse": {
@@ -407,9 +344,7 @@
         "total_steps",
         "workflow_id"
       ],
-      "spec_only": [
-        "result"
-      ]
+      "spec_only": []
     },
     "StaticPolicy": {
       "sdk_only": [
@@ -423,40 +358,15 @@
         "created_at",
         "has_override",
         "organization_id",
-        "policy_id",
-        "priority",
         "tenant_id",
         "updated_at"
-      ]
-    },
-    "StepGateRequest": {
-      "sdk_only": [],
-      "spec_only": [
-        "cost_usd",
-        "tokens_in",
-        "tokens_out"
-      ]
-    },
-    "StepGateResponse": {
-      "sdk_only": [],
-      "spec_only": [
-        "decision_id"
-      ]
-    },
-    "UpdatePlanRequest": {
-      "sdk_only": [],
-      "spec_only": [
-        "metadata"
       ]
     },
     "UpdateStaticPolicyRequest": {
       "sdk_only": [
         "category"
       ],
-      "spec_only": [
-        "priority",
-        "tags"
-      ]
+      "spec_only": []
     },
     "UsageBreakdown": {
       "sdk_only": [
@@ -466,46 +376,17 @@
       ],
       "spec_only": []
     },
-    "UsageBreakdownItem": {
-      "sdk_only": [],
-      "spec_only": [
-        "group_by"
-      ]
-    },
     "UsageRecord": {
       "sdk_only": [
         "timestamp"
       ],
-      "spec_only": [
-        "created_at",
-        "error_message",
-        "latency_ms",
-        "success",
-        "team_id",
-        "tenant_id",
-        "user_id",
-        "workflow_id"
-      ]
+      "spec_only": []
     },
     "UsageSummary": {
       "sdk_only": [
         "period"
       ],
       "spec_only": []
-    },
-    "WebhookSubscription": {
-      "sdk_only": [],
-      "spec_only": [
-        "org_id",
-        "secret",
-        "tenant_id"
-      ]
-    },
-    "WorkflowStatusResponse": {
-      "sdk_only": [],
-      "spec_only": [
-        "metadata"
-      ]
     },
     "WorkflowStepInfo": {
       "sdk_only": [


### PR DESCRIPTION
## Summary

**Correction to the overnight handoff:** the earlier claim that "Python baseline is clean — 0 drift via pydantic aliases" was wrong. That was a key-name confusion — Python's baseline uses \`per_model_drift\` while TS/Go use \`per_type_drift\`. A proper per-entry audit found 36 drift entries, very similar in pattern to the TS+Go sweeps.

This PR ships the same Cat B + RENAME_SAFE + UNRECOVERABLE work that landed in axonflow-sdk-typescript#185 and axonflow-sdk-go#133. **No version bump triggered** — all changes are additive or marked \`DEPRECATED\` for source-compat.

## Changes

### Cat B (pure additions; SDK was missing wire fields)

- **\`WebhookSubscription.secret\`** — HMAC-SHA256 signing key surfaced on \`create_webhook\` response. Security-critical: required to verify the \`X-AxonFlow-Signature\` header on inbound deliveries. Also adds \`org_id\` / \`tenant_id\`.
- **\`StepGateRequest.{tokens_in, tokens_out, cost_usd}\`** — budget policies can now evaluate gate-time cost estimates.
- **\`StepGateResponse.decision_id\`** — unique audit correlator.
- **\`ListWorkflowsResponse.{limit, offset}\`** — pagination echo.
- **\`StaticPolicy.{policy_id, priority}\`** — wire-canonical fields.
- **\`CreateStaticPolicyRequest.{priority, tags}\`** + **\`UpdateStaticPolicyRequest.{priority, tags}\`** — match spec.
- **\`UpdatePlanRequest.metadata\`** — accept arbitrary plan metadata.
- **\`UsageBreakdownItem.group_by\`** — dimension name.
- **\`BudgetAlert.acknowledged\`** — alert dismissal flag.
- **\`Budget.{org_id, tenant_id}\`** — ownership scoping.
- **\`WorkflowStatusResponse.metadata\`** — workflow metadata.
- **\`ExecutionSnapshot.retry_count\`** — retry counter.
- **\`Finding.article\`** — regulatory article reference.
- **\`MCPCheckInputRequest.{client_id, tenant_id, user_id, user_role, user_token}\`** + **\`MCPCheckOutputRequest.{client_id, tenant_id, user_id, user_token}\`** — match the spec scoping fields.

### RENAME_SAFE (orphan reads fixed; old fields kept as DEPRECATED for source-compat)

The audit found these fields were declared in the SDK but read None against actual server responses (the wire emits a different key). Wire-canonical names added; legacy fields marked DEPRECATED with removal scheduled for v7:

- \`DynamicPolicyMatch.message\` (was \`reason\` reading None)
- \`ExfiltrationCheckInfo.{exceeded, limit_type}\` (was \`within_limits\` reading None)
- \`PolicyOverride.{id, enabled_override}\` (was \`active\` reading None)
- \`PolicyVersion.{id, policy_id, change_summary, snapshot}\` (was \`change_description\` / \`previous_values\` / \`new_values\` reading None)
- \`CancelPlanResponse.success\` (was \`message\` reading None)
- \`CreateWorkflowResponse.started_at\` (was \`created_at\` and \`source\` reading None)
- \`UsageRecord.{created_at, success, error_message, latency_ms, team_id, tenant_id, user_id, workflow_id}\` (was \`timestamp\` reading None)
- \`ResumePlanResponse.result\` + 6 fields marked DEPRECATED that were declared but never populated (\`workflow_id\`, \`message\`, \`step_result\`, \`next_step\`, \`next_step_name\`, \`total_steps\`)
- \`PlanResponse\` gains wire top-level fields (\`success\`, \`version\`, \`result\`, \`error\`, \`workflow_execution_id\`, \`policy_info\`)

## Spec issues already filed

- axonflow-enterprise#1708 — \`AISystemRegistry.materiality\` is wrong field name (server emits \`materiality_classification\`); spec needs update, no SDK change.
- axonflow-enterprise#1709 — \`DynamicPolicyInfo\` schema completely wrong shape (server, all 4 SDKs agree; spec drift).

## Verification

- Tests: ✅ 924 pass, 29 skipped
- Coverage: 80.96%
- Wire-shape baseline regenerated: 36 → 26 drift entries
- All Cat B types resolved (no SDK-only or spec-only entries)

## Note on baseline regeneration

The refresh script (\`scripts/refresh_wire_shape_baseline.py\`) needs an explicit \`PYTHONPATH=$PWD\` when run from the worktree if you have an editable install of axonflow elsewhere on your system; otherwise \`import axonflow\` resolves to the editable install instead of the worktree's local copy and the baseline refreshes against stale types. The CI workflow runs from a fresh clone so this isn't an issue there.

## Test plan

- [x] All tests pass
- [x] Coverage above threshold
- [x] Baseline regenerated correctly (verified by inspection)
- [ ] CI on this PR is green