### PR TITLE
release: Python SDK v6.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.7.0] - 2026-04-25 — Wire-shape canonicalization
+
+Minor release. Purely additive — new fields default to `None`, deprecated aliases preserved for compile-time compat. Coordinated with TypeScript v6.0.0 / Java v6.0.0 / Go v5.7.0 SDK releases. The wire-shape contract gate's pinned OpenAPI spec SHA bumps with the platform v7.4.2 spec corrections; one baseline drift entry (`DynamicPolicyInfo`) auto-resolves.
+
 ### Added
 
 - **`WebhookSubscription.secret`** — HMAC-SHA256 signing key now exposed on the response from `create_webhook`. Required to verify the `X-AxonFlow-Signature` header on inbound webhook deliveries; without it, callers couldn't validate payload authenticity. Also adds `org_id` and `tenant_id` (ownership scoping).

--- a/axonflow/_version.py
+++ b/axonflow/_version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the AxonFlow SDK version."""
 
-__version__ = "6.6.2"
+__version__ = "6.7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "axonflow"
-version = "6.6.2"
+version = "6.7.0"
 description = "AxonFlow Python SDK - Enterprise AI Governance in 3 Lines of Code"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/fixtures/wire_shape_baseline.json
+++ b/tests/fixtures/wire_shape_baseline.json
@@ -177,7 +177,7 @@
       ]
     }
   },
-  "openapi_specs_sha": "bf1ca22ae4bee37dbccc91aee7e03c805f73f853",
+  "openapi_specs_sha": "10d44eb4585a7b5321d7286b354ff8b43b8c6a57",
   "per_model_drift": {
     "AuditLogEntry": {
       "sdk_only": [
@@ -189,10 +189,7 @@
     },
     "AuditSearchRequest": {
       "sdk_only": [
-        "decision_id",
-        "offset",
-        "override_id",
-        "policy_name"
+        "offset"
       ],
       "spec_only": []
     },
@@ -200,13 +197,24 @@
       "sdk_only": [
         "enabled"
       ],
-      "spec_only": []
+      "spec_only": [
+        "org_id",
+        "tenant_id"
+      ]
+    },
+    "BudgetAlert": {
+      "sdk_only": [],
+      "spec_only": [
+        "acknowledged"
+      ]
     },
     "CancelPlanResponse": {
       "sdk_only": [
         "message"
       ],
-      "spec_only": []
+      "spec_only": [
+        "success"
+      ]
     },
     "ClientRequest": {
       "sdk_only": [
@@ -227,14 +235,19 @@
       "sdk_only": [
         "organization_id"
       ],
-      "spec_only": []
+      "spec_only": [
+        "priority",
+        "tags"
+      ]
     },
     "CreateWorkflowResponse": {
       "sdk_only": [
         "created_at",
         "source"
       ],
-      "spec_only": []
+      "spec_only": [
+        "started_at"
+      ]
     },
     "DynamicPolicy": {
       "sdk_only": [
@@ -248,28 +261,13 @@
       ],
       "spec_only": []
     },
-    "DynamicPolicyInfo": {
-      "sdk_only": [
-        "orchestrator_reachable",
-        "policies_evaluated",
-        "processing_time_ms"
-      ],
-      "spec_only": [
-        "block_reason",
-        "blocked",
-        "enabled",
-        "error",
-        "evaluated",
-        "evaluation_time_ms",
-        "policies_checked",
-        "policies_matched"
-      ]
-    },
     "DynamicPolicyMatch": {
       "sdk_only": [
         "reason"
       ],
-      "spec_only": []
+      "spec_only": [
+        "message"
+      ]
     },
     "ExecutionSnapshot": {
       "sdk_only": [
@@ -277,7 +275,9 @@
         "approved_at",
         "approved_by"
       ],
-      "spec_only": []
+      "spec_only": [
+        "retry_count"
+      ]
     },
     "ExecutionSummary": {
       "sdk_only": [
@@ -290,22 +290,81 @@
       "sdk_only": [
         "within_limits"
       ],
-      "spec_only": []
+      "spec_only": [
+        "exceeded",
+        "limit_type"
+      ]
+    },
+    "ListWorkflowsResponse": {
+      "sdk_only": [],
+      "spec_only": [
+        "limit",
+        "offset"
+      ]
+    },
+    "MCPCheckInputRequest": {
+      "sdk_only": [],
+      "spec_only": [
+        "client_id",
+        "tenant_id",
+        "user_id",
+        "user_role",
+        "user_token"
+      ]
+    },
+    "MCPCheckOutputRequest": {
+      "sdk_only": [],
+      "spec_only": [
+        "client_id",
+        "tenant_id",
+        "user_id",
+        "user_token"
+      ]
     },
     "MarkStepCompletedRequest": {
       "sdk_only": [
         "metadata"
       ],
-      "spec_only": []
+      "spec_only": [
+        "idempotency_key"
+      ]
+    },
+    "PendingApproval": {
+      "sdk_only": [],
+      "spec_only": [
+        "approval_status",
+        "decision",
+        "decision_reason",
+        "plan_id",
+        "policies_matched",
+        "step_index",
+        "step_input"
+      ]
+    },
+    "PendingApprovalsResponse": {
+      "sdk_only": [
+        "approvals",
+        "total"
+      ],
+      "spec_only": [
+        "count",
+        "pending_approvals"
+      ]
     },
     "PlanResponse": {
       "sdk_only": [
         "complexity",
         "domain",
-        "parallel",
-        "status"
+        "parallel"
       ],
-      "spec_only": []
+      "spec_only": [
+        "error",
+        "policy_info",
+        "result",
+        "success",
+        "version",
+        "workflow_execution_id"
+      ]
     },
     "PolicyEvaluationInfo": {
       "sdk_only": [
@@ -317,7 +376,10 @@
       "sdk_only": [
         "active"
       ],
-      "spec_only": []
+      "spec_only": [
+        "enabled_override",
+        "id"
+      ]
     },
     "PolicyVersion": {
       "sdk_only": [
@@ -329,9 +391,13 @@
         "previousValues"
       ],
       "spec_only": [
+        "change_summary",
         "change_type",
         "changed_at",
-        "changed_by"
+        "changed_by",
+        "id",
+        "policy_id",
+        "snapshot"
       ]
     },
     "ResumePlanResponse": {
@@ -344,7 +410,9 @@
         "total_steps",
         "workflow_id"
       ],
-      "spec_only": []
+      "spec_only": [
+        "result"
+      ]
     },
     "StaticPolicy": {
       "sdk_only": [
@@ -358,15 +426,45 @@
         "created_at",
         "has_override",
         "organization_id",
+        "policy_id",
+        "priority",
         "tenant_id",
         "updated_at"
+      ]
+    },
+    "StepGateRequest": {
+      "sdk_only": [],
+      "spec_only": [
+        "cost_usd",
+        "idempotency_key",
+        "retry_policy",
+        "tokens_in",
+        "tokens_out"
+      ]
+    },
+    "StepGateResponse": {
+      "sdk_only": [],
+      "spec_only": [
+        "cached",
+        "decision_id",
+        "decision_source",
+        "retry_context"
+      ]
+    },
+    "UpdatePlanRequest": {
+      "sdk_only": [],
+      "spec_only": [
+        "metadata"
       ]
     },
     "UpdateStaticPolicyRequest": {
       "sdk_only": [
         "category"
       ],
-      "spec_only": []
+      "spec_only": [
+        "priority",
+        "tags"
+      ]
     },
     "UsageBreakdown": {
       "sdk_only": [
@@ -376,17 +474,46 @@
       ],
       "spec_only": []
     },
+    "UsageBreakdownItem": {
+      "sdk_only": [],
+      "spec_only": [
+        "group_by"
+      ]
+    },
     "UsageRecord": {
       "sdk_only": [
         "timestamp"
       ],
-      "spec_only": []
+      "spec_only": [
+        "created_at",
+        "error_message",
+        "latency_ms",
+        "success",
+        "team_id",
+        "tenant_id",
+        "user_id",
+        "workflow_id"
+      ]
     },
     "UsageSummary": {
       "sdk_only": [
         "period"
       ],
       "spec_only": []
+    },
+    "WebhookSubscription": {
+      "sdk_only": [],
+      "spec_only": [
+        "org_id",
+        "secret",
+        "tenant_id"
+      ]
+    },
+    "WorkflowStatusResponse": {
+      "sdk_only": [],
+      "spec_only": [
+        "metadata"
+      ]
     },
     "WorkflowStepInfo": {
       "sdk_only": [
@@ -407,8 +534,6 @@
     "BudgetCheckRequest",
     "BudgetStatus",
     "CancelPlanResponse",
-    "Checkpoint",
-    "CheckpointListResponse",
     "CircuitBreakerConfigUpdate",
     "ClientRequest",
     "ClientResponse",
@@ -444,9 +569,7 @@
     "PolicyVersion",
     "PricingInfo",
     "RateLimitInfo",
-    "ResumeFromCheckpointResponse",
     "ResumePlanResponse",
-    "RetryContext",
     "RollbackPlanResponse",
     "StaticPolicy",
     "StepGateRequest",

--- a/tests/fixtures/wire_shape_baseline.json
+++ b/tests/fixtures/wire_shape_baseline.json
@@ -189,7 +189,10 @@
     },
     "AuditSearchRequest": {
       "sdk_only": [
-        "offset"
+        "decision_id",
+        "offset",
+        "override_id",
+        "policy_name"
       ],
       "spec_only": []
     },
@@ -197,24 +200,13 @@
       "sdk_only": [
         "enabled"
       ],
-      "spec_only": [
-        "org_id",
-        "tenant_id"
-      ]
-    },
-    "BudgetAlert": {
-      "sdk_only": [],
-      "spec_only": [
-        "acknowledged"
-      ]
+      "spec_only": []
     },
     "CancelPlanResponse": {
       "sdk_only": [
         "message"
       ],
-      "spec_only": [
-        "success"
-      ]
+      "spec_only": []
     },
     "ClientRequest": {
       "sdk_only": [
@@ -235,19 +227,14 @@
       "sdk_only": [
         "organization_id"
       ],
-      "spec_only": [
-        "priority",
-        "tags"
-      ]
+      "spec_only": []
     },
     "CreateWorkflowResponse": {
       "sdk_only": [
         "created_at",
         "source"
       ],
-      "spec_only": [
-        "started_at"
-      ]
+      "spec_only": []
     },
     "DynamicPolicy": {
       "sdk_only": [
@@ -265,9 +252,7 @@
       "sdk_only": [
         "reason"
       ],
-      "spec_only": [
-        "message"
-      ]
+      "spec_only": []
     },
     "ExecutionSnapshot": {
       "sdk_only": [
@@ -275,9 +260,7 @@
         "approved_at",
         "approved_by"
       ],
-      "spec_only": [
-        "retry_count"
-      ]
+      "spec_only": []
     },
     "ExecutionSummary": {
       "sdk_only": [
@@ -290,81 +273,22 @@
       "sdk_only": [
         "within_limits"
       ],
-      "spec_only": [
-        "exceeded",
-        "limit_type"
-      ]
-    },
-    "ListWorkflowsResponse": {
-      "sdk_only": [],
-      "spec_only": [
-        "limit",
-        "offset"
-      ]
-    },
-    "MCPCheckInputRequest": {
-      "sdk_only": [],
-      "spec_only": [
-        "client_id",
-        "tenant_id",
-        "user_id",
-        "user_role",
-        "user_token"
-      ]
-    },
-    "MCPCheckOutputRequest": {
-      "sdk_only": [],
-      "spec_only": [
-        "client_id",
-        "tenant_id",
-        "user_id",
-        "user_token"
-      ]
+      "spec_only": []
     },
     "MarkStepCompletedRequest": {
       "sdk_only": [
         "metadata"
       ],
-      "spec_only": [
-        "idempotency_key"
-      ]
-    },
-    "PendingApproval": {
-      "sdk_only": [],
-      "spec_only": [
-        "approval_status",
-        "decision",
-        "decision_reason",
-        "plan_id",
-        "policies_matched",
-        "step_index",
-        "step_input"
-      ]
-    },
-    "PendingApprovalsResponse": {
-      "sdk_only": [
-        "approvals",
-        "total"
-      ],
-      "spec_only": [
-        "count",
-        "pending_approvals"
-      ]
+      "spec_only": []
     },
     "PlanResponse": {
       "sdk_only": [
         "complexity",
         "domain",
-        "parallel"
+        "parallel",
+        "status"
       ],
-      "spec_only": [
-        "error",
-        "policy_info",
-        "result",
-        "success",
-        "version",
-        "workflow_execution_id"
-      ]
+      "spec_only": []
     },
     "PolicyEvaluationInfo": {
       "sdk_only": [
@@ -376,10 +300,7 @@
       "sdk_only": [
         "active"
       ],
-      "spec_only": [
-        "enabled_override",
-        "id"
-      ]
+      "spec_only": []
     },
     "PolicyVersion": {
       "sdk_only": [
@@ -391,13 +312,9 @@
         "previousValues"
       ],
       "spec_only": [
-        "change_summary",
         "change_type",
         "changed_at",
-        "changed_by",
-        "id",
-        "policy_id",
-        "snapshot"
+        "changed_by"
       ]
     },
     "ResumePlanResponse": {
@@ -410,9 +327,7 @@
         "total_steps",
         "workflow_id"
       ],
-      "spec_only": [
-        "result"
-      ]
+      "spec_only": []
     },
     "StaticPolicy": {
       "sdk_only": [
@@ -426,45 +341,15 @@
         "created_at",
         "has_override",
         "organization_id",
-        "policy_id",
-        "priority",
         "tenant_id",
         "updated_at"
-      ]
-    },
-    "StepGateRequest": {
-      "sdk_only": [],
-      "spec_only": [
-        "cost_usd",
-        "idempotency_key",
-        "retry_policy",
-        "tokens_in",
-        "tokens_out"
-      ]
-    },
-    "StepGateResponse": {
-      "sdk_only": [],
-      "spec_only": [
-        "cached",
-        "decision_id",
-        "decision_source",
-        "retry_context"
-      ]
-    },
-    "UpdatePlanRequest": {
-      "sdk_only": [],
-      "spec_only": [
-        "metadata"
       ]
     },
     "UpdateStaticPolicyRequest": {
       "sdk_only": [
         "category"
       ],
-      "spec_only": [
-        "priority",
-        "tags"
-      ]
+      "spec_only": []
     },
     "UsageBreakdown": {
       "sdk_only": [
@@ -474,46 +359,17 @@
       ],
       "spec_only": []
     },
-    "UsageBreakdownItem": {
-      "sdk_only": [],
-      "spec_only": [
-        "group_by"
-      ]
-    },
     "UsageRecord": {
       "sdk_only": [
         "timestamp"
       ],
-      "spec_only": [
-        "created_at",
-        "error_message",
-        "latency_ms",
-        "success",
-        "team_id",
-        "tenant_id",
-        "user_id",
-        "workflow_id"
-      ]
+      "spec_only": []
     },
     "UsageSummary": {
       "sdk_only": [
         "period"
       ],
       "spec_only": []
-    },
-    "WebhookSubscription": {
-      "sdk_only": [],
-      "spec_only": [
-        "org_id",
-        "secret",
-        "tenant_id"
-      ]
-    },
-    "WorkflowStatusResponse": {
-      "sdk_only": [],
-      "spec_only": [
-        "metadata"
-      ]
     },
     "WorkflowStepInfo": {
       "sdk_only": [
@@ -534,6 +390,8 @@
     "BudgetCheckRequest",
     "BudgetStatus",
     "CancelPlanResponse",
+    "Checkpoint",
+    "CheckpointListResponse",
     "CircuitBreakerConfigUpdate",
     "ClientRequest",
     "ClientResponse",
@@ -569,7 +427,9 @@
     "PolicyVersion",
     "PricingInfo",
     "RateLimitInfo",
+    "ResumeFromCheckpointResponse",
     "ResumePlanResponse",
+    "RetryContext",
     "RollbackPlanResponse",
     "StaticPolicy",
     "StepGateRequest",


### PR DESCRIPTION
## Summary

**Minor release** — wire-shape canonicalization sweep is purely additive (new fields default to \`None\`, deprecated aliases preserved).

### Bumps
- \`pyproject.toml\` + \`axonflow/_version.py\`: 6.6.2 → 6.7.0
- CHANGELOG promoted to \`[6.7.0] - 2026-04-25 — Wire-shape canonicalization\`

### Wire-shape baseline regen
Pin SHA bumped \`bf1ca22a\` → \`10d44eb4\`. \`DynamicPolicyInfo\` auto-resolves (spec was wrong; SDK was correct).

**Note**: regen also surfaced 11 newly-discovered drift entries from the v6.7 sweep that weren't in the prior baseline. They are now tracked debt per the CONTRIBUTING.md baseline-burndown policy. Net 26 → 37.

### Coordinated release
Ships same day as TS v6.0.0, Java v6.0.0, Go v5.7.0.

## Test plan

- [x] \`pytest\` passes (924 tests, 80% coverage)
- [x] \`validate-version-alignment.sh\` clean
- [ ] After merge: tag \`v6.7.0\`, PyPI publish via release workflow