### PR TITLE
docs(readme): add Evidence Export + Policy Simulation rows to Eval table

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,10 @@ Need more capacity than Community without moving to Enterprise? Evaluation uses 
 | Audit retention | 3 days | 14 days | 3650 days |
 | Concurrent executions | 5 | 25 | Unlimited |
 | Pending execution approvals | 5 | 25 | Unlimited |
+| Evidence export (CSV / JSON) | — | 5,000 records · 14d window · 3/day | Unlimited |
+| Policy simulation | — | 300 / day | Unlimited |
 
-Concurrent executions applies to MAP and WCP executions per tenant. Pending execution approvals applies to MAP confirm/step mode and WCP approval queues.
+Concurrent executions applies to MAP and WCP executions per tenant. Pending execution approvals applies to MAP confirm/step mode and WCP approval queues. Evidence export pulls audit records as CSV/JSON for compliance review. Policy simulation lets you dry-run a rule against real traffic before enabling it.
 
 [Get a free Evaluation license](https://getaxonflow.com/evaluation-license?utm_source=readme_sdk_python_eval) · [Full feature matrix](https://docs.getaxonflow.com/docs/features/community-vs-enterprise?utm_source=readme_sdk_python_eval)
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ Need more capacity than Community without moving to Enterprise? Evaluation uses 
 | Evidence export (CSV / JSON) | — | 5,000 records · 14d window · 3/day | Unlimited |
 | Policy simulation | — | 300 / day | Unlimited |
 
-Concurrent executions applies to MAP and WCP executions per tenant. Pending execution approvals applies to MAP confirm/step mode and WCP approval queues. Evidence export pulls audit records as CSV/JSON for compliance review. Policy simulation lets you dry-run a rule against real traffic before enabling it.
+Concurrent executions applies to MAP and WCP executions per tenant. Pending execution approvals applies to MAP confirm/step mode and WCP approval queues.
+
+> **Note:** Evidence export and policy simulation are licensed AxonFlow platform capabilities available alongside the SDK on your deployed platform — not language-specific SDK helpers. Access them via the platform API or customer portal. The SDK row is included to show what your licensed deployment unlocks at each tier.
 
 [Get a free Evaluation license](https://getaxonflow.com/evaluation-license?utm_source=readme_sdk_python_eval) · [Full feature matrix](https://docs.getaxonflow.com/docs/features/community-vs-enterprise?utm_source=readme_sdk_python_eval)
 


### PR DESCRIPTION
## Summary

Brings the SDK README Eval Tier table from 5 rows to 7 rows, matching the four plugin READMEs.

**Why:** review feedback flagged that SDK READMEs showed a more compact 5-row table while plugin READMEs showed 7 rows. Audience-tuned rows are fine, but the level of detail should match across both README families.

**Rows added:**
- `Evidence export (CSV / JSON) — | 5,000 records · 14d window · 3/day | Unlimited`
- `Policy simulation — | 300 / day | Unlimited`

**Why these specific rows for SDKs:** both are tier-gated runtime features verified directly against `platform/agent/license/tier_support.go` (`MaxEvidenceExportRecords`, `MaxEvidenceWindowDays`, `MaxEvidenceExportsPerDay`, `MaxSimulationsPerDay`), and both are meaningful to SDK users moving from Community to Eval (audit/compliance teams care about Evidence Export; SDK developers testing rules care about Policy Simulation).

**Plugin READMEs unchanged** — already at 7 audience-tuned rows. Different rows (HITL approval gates, session overrides) for that audience.

## Test plan
- [ ] Preview renders 7-row table
- [ ] Numbers match runtime config