### PR TITLE
review: ship the items deferred from #166

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,17 +25,23 @@ env:
 
 jobs:
   # Contract tests run on every PR and push. No network, no stack.
+  # Matrixed across the same Python versions ci.yml exercises (3.10/3.11/3.12)
+  # so version-specific drift surfaces at PR time, not at release time.
   contract-tests:
-    name: Contract Tests
+    name: Contract Tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
 
       - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,7 @@ ignore = [
 "axonflow/adapters/langgraph_wrapper.py" = ["ARG002", "PLC0415", "E501"]  # Callback signatures must match base; lazy import of langchain-core
 "axonflow/adapters/langchain.py" = ["PLC0415", "A002", "BLE001", "S110", "SIM105"]  # Lazy import of langchain-core; `input` matches LangChain interface; broad except is intentional for non-fatal audit
 "axonflow/adapters/tool_wrapper.py" = ["PLC0415", "A002", "TRY301"]  # Lazy import of langchain-core; `input` matches BaseTool interface; raise in _run_coro_sync try block
-"examples/**/*.py" = ["T201", "ANN", "S106", "ERA001", "BLE001", "PLC0415", "F541"]
+"examples/**/*.py" = ["T201", "ANN", "S106", "ERA001", "PLC0415", "F541"]  # BLE001 (blind-except) intentionally NOT in this list — examples must demonstrate proper exception handling
 "examples/wcp_retry_idempotency.py" = ["T201", "ANN", "S101", "S106", "ERA001", "BLE001", "PLC0415", "F541", "E501"]  # E2E validation script: bare asserts + long assertion strings are intentional
 "scripts/**/*.py" = ["T201", "ANN", "S106", "BLE001", "UP045", "DTZ005", "PTH123"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,8 +19,28 @@ from axonflow import AxonFlow
 
 @pytest.fixture(autouse=True)
 def _disable_telemetry(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Disable telemetry in all tests to prevent unexpected HTTP calls."""
+    """Disable telemetry in all tests AND block real HTTP egress from the
+    telemetry path.
+
+    The DO_NOT_TRACK env var is the documented opt-out, but a future test
+    could legitimately delete it (to exercise the telemetry path itself)
+    and the suite would start firing real pings at the prod checkpoint.
+    Defensive: also patch the httpx.get / httpx.post call sites the
+    telemetry module uses so a deleted DO_NOT_TRACK can't leak.
+    """
+    import httpx
+
     monkeypatch.setenv("DO_NOT_TRACK", "1")
+
+    def _blocked_http(*_args, **_kwargs):
+        raise RuntimeError(
+            "Real HTTP egress is blocked in unit tests. "
+            "Use httpx.MockTransport or a recorded fixture for tests that "
+            "exercise the telemetry path."
+        )
+
+    monkeypatch.setattr(httpx, "get", _blocked_http)
+    monkeypatch.setattr(httpx, "post", _blocked_http)
 
 
 # ============================================================================

--- a/tests/test_try_mode.py
+++ b/tests/test_try_mode.py
@@ -1,0 +1,98 @@
+"""Tests for AXONFLOW_TRY=1 try-mode auto-endpoint resolution.
+
+These cover the env-var-driven endpoint override at axonflow/client.py:480-491
+which previously had zero coverage.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from axonflow import AxonFlow
+
+
+def test_try_mode_resolves_to_try_endpoint(monkeypatch):
+    """AXONFLOW_TRY=1 should ignore endpoint+AXONFLOW_AGENT_URL and route to try.getaxonflow.com."""
+    monkeypatch.setenv("AXONFLOW_TRY", "1")
+    monkeypatch.delenv("AXONFLOW_AGENT_URL", raising=False)
+
+    client = AxonFlow(client_id="test-client", client_secret="test-secret")
+
+    assert client._config.endpoint == "https://try.getaxonflow.com"
+
+
+def test_try_mode_overrides_explicit_endpoint(monkeypatch):
+    """AXONFLOW_TRY=1 takes precedence over an explicitly-passed endpoint."""
+    monkeypatch.setenv("AXONFLOW_TRY", "1")
+
+    client = AxonFlow(
+        endpoint="http://localhost:8080",
+        client_id="test-client",
+        client_secret="test-secret",
+    )
+
+    assert client._config.endpoint == "https://try.getaxonflow.com"
+
+
+def test_try_mode_overrides_axonflow_agent_url_env(monkeypatch):
+    """AXONFLOW_TRY=1 takes precedence over AXONFLOW_AGENT_URL env var."""
+    monkeypatch.setenv("AXONFLOW_TRY", "1")
+    monkeypatch.setenv("AXONFLOW_AGENT_URL", "http://localhost:9999")
+
+    client = AxonFlow(client_id="test-client", client_secret="test-secret")
+
+    assert client._config.endpoint == "https://try.getaxonflow.com"
+
+
+def test_try_mode_requires_client_id(monkeypatch):
+    """AXONFLOW_TRY=1 without client_id raises TypeError with a clear message."""
+    monkeypatch.setenv("AXONFLOW_TRY", "1")
+
+    with pytest.raises(TypeError, match="client_id is required in try mode"):
+        AxonFlow()
+
+
+def test_try_mode_requires_client_id_even_with_endpoint(monkeypatch):
+    """An explicit endpoint doesn't satisfy try mode's client_id requirement."""
+    monkeypatch.setenv("AXONFLOW_TRY", "1")
+
+    with pytest.raises(TypeError, match="client_id is required in try mode"):
+        AxonFlow(endpoint="https://something.example.com")
+
+
+def test_try_mode_off_uses_normal_endpoint_resolution(monkeypatch):
+    """Without AXONFLOW_TRY=1 the SDK uses the explicit endpoint."""
+    monkeypatch.delenv("AXONFLOW_TRY", raising=False)
+    monkeypatch.delenv("AXONFLOW_AGENT_URL", raising=False)
+
+    client = AxonFlow(
+        endpoint="http://localhost:8080",
+        client_id="test-client",
+        client_secret="test-secret",
+    )
+
+    assert client._config.endpoint == "http://localhost:8080"
+
+
+def test_try_mode_unset_falls_back_to_agent_url_env(monkeypatch):
+    """Without AXONFLOW_TRY=1, AXONFLOW_AGENT_URL is the fallback when no endpoint is passed."""
+    monkeypatch.delenv("AXONFLOW_TRY", raising=False)
+    monkeypatch.setenv("AXONFLOW_AGENT_URL", "http://localhost:9999")
+
+    client = AxonFlow(client_id="test-client", client_secret="test-secret")
+
+    assert client._config.endpoint == "http://localhost:9999"
+
+
+def test_try_mode_disabled_with_other_value(monkeypatch):
+    """AXONFLOW_TRY=other-value is treated as off (only the literal "1" enables it)."""
+    monkeypatch.setenv("AXONFLOW_TRY", "true")
+    monkeypatch.delenv("AXONFLOW_AGENT_URL", raising=False)
+
+    client = AxonFlow(
+        endpoint="http://localhost:8080",
+        client_id="test-client",
+        client_secret="test-secret",
+    )
+
+    assert client._config.endpoint == "http://localhost:8080"


### PR DESCRIPTION
## Summary

User feedback after #166: \"all means all, don't defer.\" Closing the loop on the 4 items deferred-with-reason in that PR.

## P1 #9 — AXONFLOW_TRY=1 zero test coverage (FIXED)

Added \`tests/test_try_mode.py\`. 8 tests covering every branch of \`axonflow/client.py:480-491\`:

- try-mode resolves to \`https://try.getaxonflow.com\`
- try-mode overrides explicit endpoint
- try-mode overrides \`AXONFLOW_AGENT_URL\` env var
- try-mode requires \`client_id\` (TypeError with clear message)
- try-mode requires \`client_id\` even with explicit endpoint
- try-mode off → uses explicit endpoint
- try-mode unset → falls back to \`AXONFLOW_AGENT_URL\`
- \`AXONFLOW_TRY=other-value\` → treated as off (only literal \`\"1\"\` enables)

All 8 pass.

## P2 #11 — BLE001 (blind-except) ignored in examples/** (FIXED)

Removed \`BLE001\` from the \`examples/**/*.py\` per-file-ignores list in \`pyproject.toml\`. Without the ignore, ruff would have caught the bare-except in \`openai_integration.py\` at PR time instead of needing a manual deep review. Verified \`ruff check examples/\` passes after #166's narrower exception handlers land.

## P2 #13 — integration.yml only runs Python 3.11 (FIXED)

\`contract-tests\` job matrixed across 3.10/3.11/3.12, matching ci.yml. Catches version-specific drift at PR time. The other two jobs (\`demo-scripts\`, \`integration\`) stay single-version since they exercise the live stack and the multiplier would 3x runtime.

## P2 #12 — conftest.py only sets DO_NOT_TRACK (FIXED)

Defensive HTTP-egress block added to the autouse \`_disable_telemetry\` fixture. Patches \`httpx.get\` / \`httpx.post\` with a \`RuntimeError\` that tells the future test author to use \`httpx.MockTransport\` or a recorded fixture. Closes the leak path where a future test legitimately deletes \`DO_NOT_TRACK\` to exercise the telemetry path and accidentally fires real pings at the prod checkpoint. Same lesson as the existing memory rule \`feedback_test_env_delete_mock_fetch.md\`.

## Test plan

- [x] \`pytest tests/test_try_mode.py\` — 8/8 pass
- [x] \`pytest tests/\` (full suite) — 948/948 pass + 29 skipped, with the new HTTP block in place
- [x] \`ruff check examples/\` clean (BLE001 enforcement re-enabled)
- [ ] CI green on PR (3-version contract-tests matrix)
- [ ] CI: integration green on push to main