### PR TITLE
fix(telemetry)!: remove DO_NOT_TRACK opt-out (BREAKING)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 env:
-  DO_NOT_TRACK: '1'
+  AXONFLOW_TELEMETRY: 'off'
 
 jobs:
   lint:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DO_NOT_TRACK: '1'
+  AXONFLOW_TELEMETRY: 'off'
 
 jobs:
   # Contract tests run on every PR and push. No network, no stack.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 env:
-  DO_NOT_TRACK: '1'
+  AXONFLOW_TELEMETRY: 'off'
 
 jobs:
   # Preflight: validate CHANGELOG has a section for the tag being released

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **BREAKING:** `DO_NOT_TRACK` is no longer honored as an AxonFlow telemetry opt-out. Use `AXONFLOW_TELEMETRY=off` instead.
+
+  `DO_NOT_TRACK` was deprecated because it is commonly inherited from host tools and developer environments (CLIs like Codex and Claude Code inject it unconditionally), which makes it an unreliable expression of user intent for AxonFlow telemetry.
+
 ### Changed
 
 - `StaticPolicy` and `PolicyVersion` now serialize their wire fields in snake_case to match the OpenAPI spec (`created_at`, `updated_at`, `organization_id`, `tenant_id`, `has_override`, `changed_at`, `changed_by`, `change_type`). camelCase aliases (`createdAt`, `changedBy`, etc.) remain accepted on input via `validation_alias=AliasChoices(...)` so existing consumers keep working; only outgoing serialization changes. **Round-trip identity is no longer preserved** for callers that built these models from camelCase dicts: `StaticPolicy.model_validate({"createdAt": "..."}).model_dump()` now emits `created_at`, not `createdAt`. Code that signs, hashes, or byte-compares serialized model bodies will see a one-time shape change; switch comparisons to operate on the snake_case shape.
@@ -19,11 +25,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ClientRequest.skip_llm` — optional flag to run policy evaluation only and return without invoking the LLM. Matches the existing platform-side request schema.
 
+### Fixed
+
+- The one-line `DO_NOT_TRACK=1 is deprecated...` `logger.warning` is no longer emitted. Removing the warning eliminates log noise that previously appeared on every client construction when `DO_NOT_TRACK=1` was set.
+
 ### CI / Testing
 
 - Nightly integration workflow runs the SDK against `try.getaxonflow.com` via the documented `POST /api/v1/register` flow. Catches drift between the SDK and the hosted community sandbox that the existing docker-compose integration job (bare local stack) cannot see. Failures auto-file or comment a tracking issue; available via `workflow_dispatch` for ad-hoc validation.
 - Wire-shape baseline burndown: every entry in `tests/fixtures/wire_shape_baseline.json::per_model_drift` now carries a `note` annotation classifying the drift (`spec-bug-pending`, `deprecated-pending-removal`, `sdk-aggregation`, or `acknowledged-sdk-superset`). Four entries remain tagged `spec-bug-pending` with a single linked tracking issue; the rest are documented as intentional or scheduled-for-removal so the baseline doubles as the burn-down ledger.
 - `scripts/refresh_wire_shape_baseline.py` now preserves the `note` field on each drift entry across regen runs so a routine refresh doesn't strip the human-authored rationale.
+- Test harness (`tests/conftest.py` autouse fixture) and CI workflows (`ci.yml`, `integration.yml`, `release.yml`) now use `AXONFLOW_TELEMETRY=off` to suppress telemetry during automated runs.
+
 
 ## [6.9.0] - 2026-04-28 — list_providers() + LLMProvider full shape
 

--- a/README.md
+++ b/README.md
@@ -442,7 +442,10 @@ No email required. Optional contact if you want a response.
 ## Telemetry
 
 This SDK sends anonymous usage telemetry (SDK version, OS, enabled features) to help improve AxonFlow.
-No prompts, payloads, or PII are ever collected. Opt out: `AXONFLOW_TELEMETRY=off` or `DO_NOT_TRACK=1`.
+No prompts, payloads, or PII are ever collected. Opt out: `AXONFLOW_TELEMETRY=off`.
+
+`DO_NOT_TRACK` is **not** honored as an opt-out for AxonFlow telemetry. It is commonly inherited from host tools and developer environments, which makes it an unreliable expression of user intent.
+
 See [Telemetry Documentation](https://docs.getaxonflow.com/docs/telemetry) for full details.
 
 ## License

--- a/axonflow/client.py
+++ b/axonflow/client.py
@@ -460,8 +460,8 @@ class AxonFlow:
             mode: Operation mode (production or sandbox)
             debug: Enable debug logging
             telemetry: Enable/disable anonymous telemetry. ``None`` uses mode default
-                (ON for production, OFF for sandbox). Set ``DO_NOT_TRACK=1`` or
-                ``AXONFLOW_TELEMETRY=off`` to opt out via environment.
+                (ON for production, OFF for sandbox). Set ``AXONFLOW_TELEMETRY=off``
+                to opt out via environment.
             timeout: Request timeout in seconds
             map_timeout: Timeout for MAP operations in seconds (default: 120s)
                         MAP operations involve multiple LLM calls and need longer timeouts

--- a/axonflow/telemetry.py
+++ b/axonflow/telemetry.py
@@ -5,7 +5,7 @@ sends it to the AxonFlow checkpoint service. The response may include the
 latest available SDK version so we can warn about outdated installs.
 
 Opt-out:
-    Set ``DO_NOT_TRACK=1`` or ``AXONFLOW_TELEMETRY=off`` in your environment.
+    Set ``AXONFLOW_TELEMETRY=off`` in your environment.
 
 Override endpoint:
     Set ``AXONFLOW_CHECKPOINT_URL`` to a custom URL.
@@ -72,26 +72,17 @@ def _is_telemetry_enabled(
     """Determine whether telemetry should fire.
 
     Priority (highest to lowest):
-    1. ``DO_NOT_TRACK=1`` environment variable  -> disabled (**deprecated**,
-       removed after 2026-05-05 in the next major release; emits a one-line
-       warning when it's the active control so operators can migrate)
-    2. ``AXONFLOW_TELEMETRY=off`` environment variable -> disabled
+    1. ``AXONFLOW_TELEMETRY=off`` environment variable -> disabled
        (canonical AxonFlow-specific opt-out)
-    3. Explicit config value (``telemetry_enabled``) -> use that
-    4. Default: ON for all modes except sandbox
+    2. Explicit config value (``telemetry_enabled``) -> use that
+    3. Default: ON for all modes except sandbox
+
+    ``DO_NOT_TRACK`` is intentionally NOT honored. It is commonly inherited
+    from host tools and developer environments (CLIs like Codex and Claude
+    Code inject it unconditionally), which makes it an unreliable expression
+    of user intent for AxonFlow telemetry.
     """
     # Environment-level opt-out always wins.
-    if os.environ.get("DO_NOT_TRACK", "").strip() == "1":
-        # Only warn when DO_NOT_TRACK is the active control. If the caller has
-        # also set AXONFLOW_TELEMETRY=off, they've already migrated.
-        if os.environ.get("AXONFLOW_TELEMETRY", "").strip().lower() != "off":
-            logger.warning(
-                "DO_NOT_TRACK=1 is deprecated as an AxonFlow telemetry opt-out "
-                "and will be removed after 2026-05-05 in the next major release. "
-                "Set AXONFLOW_TELEMETRY=off to opt out going forward. "
-                "See https://docs.getaxonflow.com/docs/telemetry for details."
-            )
-        return False
     if os.environ.get("AXONFLOW_TELEMETRY", "").strip().lower() == "off":
         return False
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,15 +22,15 @@ def _disable_telemetry(monkeypatch: pytest.MonkeyPatch) -> None:
     """Disable telemetry in all tests AND block real HTTP egress from the
     telemetry path.
 
-    The DO_NOT_TRACK env var is the documented opt-out, but a future test
-    could legitimately delete it (to exercise the telemetry path itself)
-    and the suite would start firing real pings at the prod checkpoint.
-    Defensive: also patch the httpx.get / httpx.post call sites the
-    telemetry module uses so a deleted DO_NOT_TRACK can't leak.
+    The AXONFLOW_TELEMETRY=off env var is the canonical opt-out, but a
+    future test could legitimately delete it (to exercise the telemetry
+    path itself) and the suite would start firing real pings at the prod
+    checkpoint. Defensive: also patch the httpx.get / httpx.post call
+    sites the telemetry module uses so a deleted opt-out env can't leak.
     """
     import httpx
 
-    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    monkeypatch.setenv("AXONFLOW_TELEMETRY", "off")
 
     def _blocked_http(*_args, **_kwargs):
         raise RuntimeError(

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -45,9 +45,7 @@ class TestIsTelemetryEnabled:
 
     def test_axonflow_off_still_disables_with_dnt_also_set(self) -> None:
         """AXONFLOW_TELEMETRY=off is the canonical opt-out and wins regardless of DNT."""
-        with patch.dict(
-            "os.environ", {"DO_NOT_TRACK": "1", "AXONFLOW_TELEMETRY": "off"}
-        ):
+        with patch.dict("os.environ", {"DO_NOT_TRACK": "1", "AXONFLOW_TELEMETRY": "off"}):
             assert _is_telemetry_enabled("production", None, True) is False
             assert _is_telemetry_enabled("production", True, True) is False
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -27,16 +27,29 @@ from axonflow.telemetry import (
 class TestIsTelemetryEnabled:
     """Tests for the telemetry opt-in / opt-out logic."""
 
-    def test_disabled_by_env_do_not_track(self) -> None:
-        """DO_NOT_TRACK=1 disables telemetry regardless of other settings."""
-        with patch.dict("os.environ", {"DO_NOT_TRACK": "1"}):
-            assert _is_telemetry_enabled("production", None, True) is False
-            assert _is_telemetry_enabled("production", True, True) is False
+    def test_do_not_track_alone_does_NOT_disable(self) -> None:
+        """DO_NOT_TRACK=1 alone is no longer honored as an AxonFlow opt-out.
+
+        Regression guard: host CLIs like Codex and Claude Code inject DNT=1
+        unconditionally, so honoring it would prevent telemetry from any
+        plugin/SDK running inside those hosts regardless of user intent.
+        """
+        with patch.dict("os.environ", {"DO_NOT_TRACK": "1"}, clear=True):
+            assert _is_telemetry_enabled("production", None, True) is True
+            assert _is_telemetry_enabled("production", True, True) is True
 
     def test_disabled_by_env_axonflow(self) -> None:
         """AXONFLOW_TELEMETRY=off disables telemetry."""
         with patch.dict("os.environ", {"AXONFLOW_TELEMETRY": "off"}):
             assert _is_telemetry_enabled("production", None, True) is False
+
+    def test_axonflow_off_still_disables_with_dnt_also_set(self) -> None:
+        """AXONFLOW_TELEMETRY=off is the canonical opt-out and wins regardless of DNT."""
+        with patch.dict(
+            "os.environ", {"DO_NOT_TRACK": "1", "AXONFLOW_TELEMETRY": "off"}
+        ):
+            assert _is_telemetry_enabled("production", None, True) is False
+            assert _is_telemetry_enabled("production", True, True) is False
 
     def test_disabled_by_env_axonflow_case_insensitive(self) -> None:
         """AXONFLOW_TELEMETRY=OFF (uppercase) also disables."""
@@ -68,10 +81,10 @@ class TestIsTelemetryEnabled:
         with patch.dict("os.environ", {}, clear=True):
             assert _is_telemetry_enabled("production", False, True) is False
 
-    def test_env_do_not_track_beats_config_true(self) -> None:
-        """Environment opt-out always wins over config=True."""
-        with patch.dict("os.environ", {"DO_NOT_TRACK": "1"}):
-            assert _is_telemetry_enabled("production", True, True) is False
+    def test_env_do_not_track_alone_does_NOT_beat_config_true(self) -> None:
+        """DNT=1 alone is no longer honored, so config=True still wins."""
+        with patch.dict("os.environ", {"DO_NOT_TRACK": "1"}, clear=True):
+            assert _is_telemetry_enabled("production", True, True) is True
 
     def test_env_axonflow_telemetry_beats_config_true(self) -> None:
         """AXONFLOW_TELEMETRY=off beats config=True."""
@@ -153,8 +166,8 @@ class TestSendTelemetryPing:
 
     @patch("axonflow.telemetry.httpx")
     def test_disabled_skips_post(self, mock_httpx: MagicMock) -> None:
-        """When telemetry is disabled, no HTTP call is made."""
-        with patch.dict("os.environ", {"DO_NOT_TRACK": "1"}):
+        """When telemetry is disabled (AXONFLOW_TELEMETRY=off), no HTTP call is made."""
+        with patch.dict("os.environ", {"AXONFLOW_TELEMETRY": "off"}):
             send_telemetry_ping(
                 mode="production",
                 endpoint="https://agent.axonflow.com",


### PR DESCRIPTION
## Summary

**BREAKING:** `DO_NOT_TRACK` is no longer honored as an AxonFlow telemetry opt-out. Use `AXONFLOW_TELEMETRY=off` instead.

`DO_NOT_TRACK` was deprecated because it is commonly inherited from host tools and developer environments (CLIs like Codex and Claude Code inject it unconditionally), which makes it an unreliable expression of user intent for AxonFlow telemetry. Major version bump at release time under explicit approval — not in this PR.

## Changes

- `axonflow/telemetry.py` — drop DNT branch + `logger.warning` deprecation message. Priority: env var > config override > mode default.
- `axonflow/client.py` — docstring for `telemetry` kwarg refreshed.
- `tests/conftest.py` — autouse `_disable_telemetry` fixture sets `AXONFLOW_TELEMETRY=off` (was: DNT=1).
- `tests/test_telemetry.py` — flip every DNT-suppress assertion + add canonical-wins coverage.
- `.github/workflows/{ci,integration,release}.yml` — migrate suppression env.
- `README.md`, `CHANGELOG.md` — updated.

## Test plan

- [x] `python -m pytest tests/test_telemetry.py` — 26/26 pass
- [ ] CI green