### PR TITLE
fix(security): restrict GITHUB_TOKEN to contents:read on heartbeat workflow

### DIFF
--- a/.github/workflows/heartbeat-real-stack.yml
+++ b/.github/workflows/heartbeat-real-stack.yml
@@ -15,6 +15,9 @@ on:
 env:
   AXONFLOW_TELEMETRY: 'off'
 
+permissions:
+  contents: read
+
 jobs:
   real-stack:
     name: real-stack ${{ matrix.os }}


### PR DESCRIPTION
## Summary

Resolves an open GitHub code-scanning alert: `actions/missing-workflow-permissions` on `.github/workflows/heartbeat-real-stack.yml:20`.

The `heartbeat-real-stack` workflow had no explicit top-level `permissions:` block, so `GITHUB_TOKEN` ran with the repository default token scopes — broader than this workflow needs. This is a CWE-275 (Permission Issues) class finding: the token had write capabilities the job never exercises.

## Fix

Added a workflow-scoped permissions block:

```yaml
permissions:
  contents: read
```

`contents: read` is the minimum required by `actions/checkout@v4` to fetch the repo. The remaining steps (setup-python, `pip install -e .`, run a localhost-only E2E driver) need no GitHub-side write access.

If a future job in this workflow needs higher privileges, it should declare them at job level rather than widening the workflow-level grant.

## Verification

- YAML parses clean: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/heartbeat-real-stack.yml'))"` returns no error.
- Diff is +3 lines, no logic change.

## Test plan

- [ ] CI green on this PR (the workflow itself runs on `pull_request` against `main`, so this branch will exercise the new permissions block end-to-end).
- [ ] Code-scanning alert auto-closes on merge.