### PR TITLE
fix(ci): nightly-try opt-out — DO_NOT_TRACK → AXONFLOW_TELEMETRY=off

### DIFF
--- a/.github/workflows/nightly-try-integration.yml
+++ b/.github/workflows/nightly-try-integration.yml
@@ -57,7 +57,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
-      DO_NOT_TRACK: '1'
+      # Suppress SDK telemetry pings from this CI run. We hit
+      # try.getaxonflow.com as the integration target, so without an
+      # explicit opt-out the SDK would fire an anonymous heartbeat
+      # against the production checkpoint endpoint and pollute external
+      # adoption metrics. AXONFLOW_TELEMETRY=off is the canonical and
+      # only opt-out as of v7.0.0 — DO_NOT_TRACK is no longer honored.
+      AXONFLOW_TELEMETRY: 'off'
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

The Nightly Try Integration workflow runs this SDK against `try.getaxonflow.com` from a GHA runner. It set `DO_NOT_TRACK=1` expecting the SDK to skip its anonymous heartbeat. As of v7.0.0 (PR #171, merged earlier today), the SDK no longer honors `DO_NOT_TRACK` — `AXONFLOW_TELEMETRY=off` is the canonical and only opt-out.

The stale env var meant every trigger of this workflow shipped 4 anonymous pings into the production `prod-checkpoint-telemetry-events` table, tagged `source=external`, polluting external adoption counts.

## Evidence

4 records at `2026-04-29T16:20Z`:

- `sdk=python`, `sdk_version=6.9.0`
- `source_ip_hash=a3ad6b3967ea...` (Microsoft Limited / Azure / GitHub Actions backend)
- `endpoint_type=remote`, `mode=production`
- 4 different `instance_id` values within a 23-second window — fresh per-process, consistent with a CI run

Cross-referenced with `gh run list --created '2026-04-29T16:00Z..2026-04-29T16:30Z'`: a `Nightly Try Integration` run started at 16:16:13Z on `feature/strict-sqli-and-planning-flags` (triggered via the workflow's `pull_request` path filter on `tests/test_integration.py`).

## Why this only affected Python

This is the only SDK across all four repos that has a workflow hitting the production checkpoint endpoint. Go/TypeScript/Java integration jobs run against local docker-compose with `AXONFLOW_TELEMETRY: 'off'` set at the workflow `env` level (the correct post-DNT opt-out).

## Fix

Replace `DO_NOT_TRACK: '1'` with `AXONFLOW_TELEMETRY: 'off'` on the single `env:` block of the `nightly-try` job. Comment added explaining why this matters and pointing at the PR #171 release.

## Audit trail

The 4 leaked records will be reclassified to `source=internal` via the `update-telemetry-records.yml` workflow (separate operation, audited via SoX-compliant trail in axonflow-business-docs).

## Test plan

- [ ] CI green on this PR
- [ ] After merge: re-trigger the Nightly Try Integration workflow once and verify no new external records appear from the GHA IP hash