### PR TITLE
fix(release): correct SDK version v7.7.0 → v7.1.0 [skip-runtime-e2e]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
      and tag v{X.Y.Z}. The release workflow's preflight checks the section
      header matches the tag. -->
 
-## [7.7.0] - 2026-05-06 — X-Axonflow-Client header + scope-aware license validation
+## [7.1.0] - 2026-05-06 — X-Axonflow-Client header + scope-aware license validation
 
 **Companion release to platform v7.7.0.** The Python SDK now sends an
 `X-Axonflow-Client` identification header on every governed request, which
@@ -28,7 +28,7 @@ license token's audience claim per the ADR-050 license matrix.
 ### Compatibility
 
 - **No public API changes.** Existing v7.0.x callers `pip install
-  --upgrade axonflow` and rebuild against v7.7.0 with no source changes.
+  --upgrade axonflow` and rebuild against v7.1.0 with no source changes.
 - **Backward-compatible against pre-v7.7.0 agents.** The header is
   silently dropped by older agents; the SDK behaves identically against
   v7.0.x / v7.1.x / v7.6.x agents as before.
@@ -41,8 +41,8 @@ license token's audience claim per the ADR-050 license matrix.
 - **Platform v7.7.0** — V1 SaaS Plugin Pro launch, license matrix,
   per-tenant tier resolution, GDPR right-to-erasure
   ([CHANGELOG](https://github.com/getaxonflow/axonflow/blob/main/CHANGELOG.md))
-- **Go SDK v7.7.0** / **TypeScript SDK v7.7.0** /
-  **Java SDK v7.7.0** — same `X-Axonflow-Client` injection
+- **Go SDK v7.1.0** / **TypeScript SDK v7.1.0** /
+  **Java SDK v7.1.0** — same `X-Axonflow-Client` injection
 - **Plugins** — Claude Code / Cursor / Codex v1.2.0; OpenClaw v2.2.0
   with Pro license token paste activating Pro features
 

--- a/axonflow/_version.py
+++ b/axonflow/_version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the AxonFlow SDK version."""
 
-__version__ = "7.7.0"
+__version__ = "7.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "axonflow"
-version = "7.7.0"
+version = "7.1.0"
 description = "AxonFlow Python SDK - Enterprise AI Governance in 3 Lines of Code"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Companion to axonflow-sdk-go fix #156. Previous release PR #182 bumped Python SDK 7.0.0 → 7.7.0 (platform-align). Wrong semver — only one substantive feature since v7.0.0 (X-Axonflow-Client header injection #180), so natural bump is v7.1.0.

## Changes
- `pyproject.toml` + `axonflow/_version.py` 7.7.0 → 7.1.0
- CHANGELOG header `[7.7.0]` → `[7.1.0]` (2026-05-06 preserved)
- Sister SDK refs (Go / TypeScript / Java) updated to v7.1.0
- Platform v7.7.0 refs kept (those are correctly the platform version)

## Skip-runtime-e2e justification

Version-correction only — no code behavior change. The X-Axonflow-Client header runtime contract was validated when #180 landed and re-confirmed when #182 merged. This PR only fixes the version string from the incorrect v7.7.0 to the semver-correct v7.1.0.