### PR TITLE
docs(examples): add explain_decision example [skip-runtime-e2e]

### DIFF
--- a/examples/explain_decision.py
+++ b/examples/explain_decision.py
@@ -35,8 +35,7 @@ async def main() -> None:
     decision_id = os.environ.get("AXONFLOW_DECISION_ID", "")
     if not decision_id:
         print(
-            "AXONFLOW_DECISION_ID must be set "
-            "(a decision_id from a recent blocked call)",
+            "AXONFLOW_DECISION_ID must be set (a decision_id from a recent blocked call)",
             file=sys.stderr,
         )
         sys.exit(2)
@@ -80,10 +79,7 @@ async def main() -> None:
         print(f"\n  override_available:           {exp.override_available}")
         if exp.override_existing_id:
             print(f"  override_existing_id:         {exp.override_existing_id}")
-        print(
-            f"  historical_hit_count_session: "
-            f"{exp.historical_hit_count_session}"
-        )
+        print(f"  historical_hit_count_session: {exp.historical_hit_count_session}")
         if exp.policy_source_link:
             print(f"  policy_source_link:           {exp.policy_source_link}")
 

--- a/examples/explain_decision.py
+++ b/examples/explain_decision.py
@@ -1,0 +1,92 @@
+"""Example: explain a previously-made AxonFlow policy decision.
+
+Implements the ADR-043 explainability flow. Given a decision_id (typically
+surfaced on the response of a blocked governed call, an audit_logs row, or
+the ``explain_decision`` MCP tool), this example fetches the structured
+explanation and renders the matched policies, risk level, and override
+availability.
+
+Required env vars:
+
+* ``AXONFLOW_AGENT_URL``       (default: http://localhost:8080)
+* ``AXONFLOW_CLIENT_ID``       (default: community)
+* ``AXONFLOW_CLIENT_SECRET``   (default: empty)
+* ``AXONFLOW_DECISION_ID``     the decision to explain
+
+Get a decision_id quickly by hitting a known-blocked policy::
+
+    curl -u "$AXONFLOW_CLIENT_ID:$AXONFLOW_CLIENT_SECRET" \\
+         -X POST $AXONFLOW_AGENT_URL/api/v1/mcp/check-input \\
+         -H 'Content-Type: application/json' \\
+         -d '{"connector_type":"postgres","operation":"execute",
+              "statement":"SELECT 1; DROP TABLE users;--","user_token":"u1"}'
+
+then read decision_id from the block response or the most recent audit row.
+"""
+
+import asyncio
+import os
+import sys
+
+from axonflow import AxonFlow
+
+
+async def main() -> None:
+    decision_id = os.environ.get("AXONFLOW_DECISION_ID", "")
+    if not decision_id:
+        print(
+            "AXONFLOW_DECISION_ID must be set "
+            "(a decision_id from a recent blocked call)",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    endpoint = os.environ.get("AXONFLOW_AGENT_URL", "http://localhost:8080")
+    print(f"Initializing AxonFlow client at {endpoint}...")
+    async with AxonFlow(
+        endpoint=endpoint,
+        client_id=os.environ.get("AXONFLOW_CLIENT_ID", "community"),
+        client_secret=os.environ.get("AXONFLOW_CLIENT_SECRET", ""),
+    ) as client:
+        print(f"Explaining decision {decision_id}...\n")
+        exp = await client.explain_decision(decision_id)
+
+        print("=== Decision Explanation ===")
+        print(f"  decision_id: {exp.decision_id}")
+        print(f"  timestamp:   {exp.timestamp.isoformat()}")
+        print(f"  decision:    {exp.decision}")
+        print(f"  reason:      {exp.reason}")
+        if exp.risk_level:
+            print(f"  risk_level:  {exp.risk_level}")
+        if exp.tool_signature:
+            print(f"  tool:        {exp.tool_signature}")
+
+        print(f"\n  policy_matches ({len(exp.policy_matches)}):")
+        for i, m in enumerate(exp.policy_matches):
+            print(
+                f"    [{i}] {m.policy_id} ({m.policy_name or '(unnamed)'}) — "
+                f"action={m.action or '-'} risk={m.risk_level or '-'} "
+                f"allow_override={m.allow_override}"
+            )
+
+        if exp.matched_rules:
+            print(f"\n  matched_rules ({len(exp.matched_rules)}):")
+            for r in exp.matched_rules:
+                print(
+                    f"    {r.policy_id} on {r.rule_id or '(no rule id)'}: "
+                    f"matched={r.matched_on or '-'}"
+                )
+
+        print(f"\n  override_available:           {exp.override_available}")
+        if exp.override_existing_id:
+            print(f"  override_existing_id:         {exp.override_existing_id}")
+        print(
+            f"  historical_hit_count_session: "
+            f"{exp.historical_hit_count_session}"
+        )
+        if exp.policy_source_link:
+            print(f"  policy_source_link:           {exp.policy_source_link}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Closes the example-parity gap: `client.explain_decision()` shipped in April but no runnable example existed. Mirror the Rust SDK pattern (axonflow-sdk-rust#29 / commit `2360282`) so a caller can copy a complete demo without reading the SDK source.

## Scope

- New `examples/explain_decision.py` (sibling of `quickstart.py`).
- Reads `AXONFLOW_DECISION_ID` from env, calls `await client.explain_decision(...)`, prints every ADR-043 field: matched policies, matched rules, decision, reason, risk level, override availability, historical hit count.
- Defaults `AXONFLOW_CLIENT_ID` to `community` (the cross-SDK Basic-auth default).

## Three-rule definition of done

**Rule 0 — Runtime proof.** Live run against the local community stack at `localhost:8080` (agent v7.7.0 / orchestrator v7.7.0):

Step 1 — trigger a real decision via curl (yields `decision_id=7a4876eb-3fd5-4467-a412-b0b42833e165`, policy `sys_sqli_drop_table`, risk `critical`).

Step 2 — explain via the new Python example (using `.venv/bin/python` since the SDK requires Python 3.10+ for PEP 604 union syntax in `axonflow/masfeat.py`):

```bash
AXONFLOW_AGENT_URL=http://localhost:8080 \
AXONFLOW_CLIENT_ID=community \
AXONFLOW_CLIENT_SECRET="" \
AXONFLOW_DECISION_ID=7a4876eb-3fd5-4467-a412-b0b42833e165 \
.venv/bin/python examples/explain_decision.py
```

Output:
```
Initializing AxonFlow client at http://localhost:8080...
Explaining decision 7a4876eb-3fd5-4467-a412-b0b42833e165...

=== Decision Explanation ===
  decision_id: 7a4876eb-3fd5-4467-a412-b0b42833e165
  timestamp:   2026-05-07T12:16:36.779420+00:00
  decision:    deny
  reason:      Detects DROP TABLE statement
  risk_level:  critical

  policy_matches (1):
    [0] sys_sqli_drop_table (DROP TABLE Statement) — action=- risk=critical allow_override=False

  override_available:           False
  historical_hit_count_session: 0
```

**Rule 1 — Self-review.** Hunk-by-hunk:
- Field accesses match `axonflow/decisions.py` exactly: `decision_id`, `timestamp`, `decision`, `reason`, `risk_level`, `tool_signature`, `policy_matches[{policy_id, policy_name, action, risk_level, allow_override}]`, `matched_rules`, `override_available`, `override_existing_id`, `historical_hit_count_session`, `policy_source_link`. ✓
- `async with AxonFlow(...) as client:` pattern matches `quickstart.py` style. ✓
- Risk_level + tool_signature + override_existing_id + policy_source_link are guarded with `if`s before printing — they're optional in the schema. ✓
- `matched_rules` is `list | None` in the schema; the `if exp.matched_rules:` guard handles both null and empty correctly. ✓

**Rule 2 — No deferred bugs.** None found in path. The example runs cleanly against the v7.7.0 platform.

## ⛔ Do not merge — V1.1 release window

Per the `feedback_v1_1_no_merge_during_release_window.md` guideline. V1.1 is the next coordinated release train; nothing lands on `main` across V1.1-related PRs until the user explicitly authorizes the V1.1 release.

## Skip-runtime-e2e justification

This SDK PR is runtime-tested by the repo's existing `integration.yml` workflow, which brings up the AxonFlow community stack via docker compose and runs every example end-to-end against it. Adding a parallel `runtime-e2e/<feature>/` subdir would duplicate that flow without adding signal.

Manual runtime proof for this PR (live stack, command + wire dump) is captured in the PR body above. The community-stack integration.yml run on this branch is the automated equivalent.

Pattern matches the existing Rust SDK convention where examples double as runtime tests (axonflow-sdk-rust commit `2360282`).