### PR TITLE
docs(changelog): scrub profile-field noise [skip-runtime-e2e]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,28 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
      and tag v{X.Y.Z}. The release workflow's preflight checks the section
      header matches the tag. -->
 
-## [8.0.1] - 2026-05-08 — Drop telemetry `profile` field
-
-**Patch release.** Mechanical revert of the `profile` field added in 8.0.0
-to the heartbeat payload. The field was sourced from `AXONFLOW_PROFILE`,
-which collides with the existing governance-engine env var of the same
-name (`platform/agent/profile.go`, ADR-036) — a customer setting
-`AXONFLOW_PROFILE=strict` for governance would have telemetry POSTs
-rejected by the server validator. The field also had no analytics
-consumer; `deployment_mode` (`self_hosted | community_saas | unknown`)
-already carries the topology dimension. Removing it eliminates the
-collision class entirely.
-
-No public API changes; `pip install --upgrade axonflow` is sufficient.
-
-### Removed
-
-- **Telemetry `profile` field.** `_build_payload` no longer reads
-  `AXONFLOW_PROFILE` and no longer emits `profile` in the heartbeat
-  payload. The env var reverts to its sole governance-engine meaning.
-  Any internal analytics queries that referenced the column should
-  switch to `deployment_mode` (already populated, same wire shape).
-
 ## [8.0.0] - 2026-05-08 — Decision history API + telemetry simplification
 
 **Major release.** The headline feature is the new decision-history client API:
@@ -85,7 +63,7 @@ telemetry contract — see `Removed` at the bottom of this entry for that.
 
 ### Telemetry payload (v1 schema, axonflow-enterprise#2008)
 
-- New heartbeat fields: `telemetry_type: "sdk"`, `profile` (from `AXONFLOW_PROFILE`, `unknown` when unset), `deployment_mode` aligned to `self_hosted | community_saas | unknown` via the new `_classify_deployment_mode` (host + `AXONFLOW_TRY=1` override).
+- New heartbeat fields: `telemetry_type: "sdk"`, `deployment_mode` aligned to `self_hosted | community_saas | unknown` via the new `_classify_deployment_mode` (host + `AXONFLOW_TRY=1` override).
 - `_classify_endpoint` no longer returns `community-saas` — that value moved off endpoint_type onto deployment_mode; analytics queries on the legacy value must update.
 
 ## [7.1.0] - 2026-05-06 — X-Axonflow-Client header + scope-aware license validation

--- a/axonflow/_version.py
+++ b/axonflow/_version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the AxonFlow SDK version."""
 
-__version__ = "8.0.1"
+__version__ = "8.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "axonflow"
-version = "8.0.1"
+version = "8.0.0"
 description = "AxonFlow Python SDK - Enterprise AI Governance in 3 Lines of Code"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

Scrub all references to the v1-telemetry `profile` field from CHANGELOG.md and revert the patch version bump. **The `profile` field never reached any tagged customer release** — its CHANGELOG mentions are internal noise.

User direction: *"This never made it to any customer so why it should be in changelog when we removed it already before the release."*

## What changed

- **`CHANGELOG.md`** — deleted the `[8.0.1] - Drop telemetry profile field` section entirely; scrubbed the `profile` mention from the `[8.0.0]` "Telemetry payload (v1 schema, ...)" bullet.
- **`axonflow/_version.py`** — reverted `__version__ = "8.0.1"` → `"8.0.0"`.
- **`pyproject.toml`** — reverted `version = "8.0.1"` → `"8.0.0"`.

## What is preserved

The remaining v8.0.0 narrative is unchanged: `client.list_decisions(opts)`, the v7→v8 migration guide (`telemetry` kwarg / `AxonFlowConfig.telemetry` removal, `send_telemetry_ping` signature change), sandbox-mode telemetry, `telemetry_type: "sdk"` field, `_classify_deployment_mode`, and the `_classify_endpoint` change.

## Skip-runtime-e2e justification

This is a documentation correction with two matching version-marker reverts. The code state was already settled in the prior release train (`ff8e111` dropped the runtime read of `AXONFLOW_PROFILE` for telemetry on `main`). No user-facing behaviour changes; version-string evaluates correctly (`exec(open('axonflow/_version.py').read())` → `8.0.0`).

## References

- getaxonflow/axonflow-enterprise#2033 — original env-var collision bug
- getaxonflow/axonflow-enterprise#2035 — code-side fix (already shipped to `main` via #189 as `ff8e111`)

## Self-review

- Confirmed only the `[8.0.1]` section + the single `profile` clause inside `[8.0.0]`'s "Telemetry payload" bullet were removed.
- Confirmed both version markers (`_version.py` + `pyproject.toml`) are reverted in lockstep.
- No stray `8.0.1` references remain under `axonflow/` or `pyproject.toml`.
- No AI attribution anywhere; DCO sign-off present.