### PR TITLE
chore(changelog): retitle v8.0.0 — Decision History API + policy_version [skip-runtime-e2e]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  and tag v{X.Y.Z}. The release workflow's preflight checks the section
  header matches the tag. -->
 
-## [8.0.0] - 2026-05-09 — Decision history API + telemetry simplification
+## [8.0.0] - 2026-05-09 — Decision History API + policy_version recorded on every decision + telemetry simplification
 
 **Major release.** The headline feature is the new decision-history client API:
 `list_decisions` for paging through recorded decisions, alongside the


### PR DESCRIPTION
## Summary

Retitle the v8.0.0 CHANGELOG entry from "Decision history API + telemetry simplification" to "Decision History API + policy_version recorded on every decision + telemetry simplification".

The two user-facing surfaces this version delivers are:
1. New `list_decisions()` client API + decision-history fanout to the four IDE plugins
2. `policy_version_at_decision` recorded inline on every static-policy decision so explain stays accurate after policies are edited

The previous title omitted the policy_version surface entirely. Retitle aligns with the v7.9.0 platform release theme.

## Skip-runtime-e2e justification

CHANGELOG-only edit. No code, no surface change.