### PR TITLE
test(2275): 401-not-retried regression test [skip-runtime-e2e]

### DIFF
--- a/tests/test_audit_tool_call.py
+++ b/tests/test_audit_tool_call.py
@@ -6,7 +6,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from axonflow import AxonFlow
-from axonflow.exceptions import AxonFlowError
+from axonflow.exceptions import AuthenticationError, AxonFlowError
 from axonflow.types import AuditToolCallRequest, AuditToolCallResponse
 
 
@@ -128,6 +128,36 @@ class TestAuditToolCall:
 
         with pytest.raises(AxonFlowError):
             await client.audit_tool_call(request)
+
+    @pytest.mark.asyncio
+    async def test_401_not_retried_issue_2275(
+        self,
+        client: AxonFlow,
+        httpx_mock: HTTPXMock,
+    ) -> None:
+        # Regression test for getaxonflow/axonflow-enterprise#2275: 401 on
+        # /api/v1/audit/tool-call must be terminal — the SDK must NOT retry
+        # an auth failure, because retrying with the same invalid token just
+        # compounds the storm on the agent.
+        #
+        # Python SDK is already safe: `_request_with_retry` only retries on
+        # `httpx.ConnectError` / `httpx.TimeoutException`, never on HTTP
+        # status codes. This test locks in the contract.
+        httpx_mock.add_response(
+            status_code=401,
+            json={"error": "unauthorized"},
+        )
+
+        request = AuditToolCallRequest(tool_name="getUserInfo")
+
+        with pytest.raises(AuthenticationError):
+            await client.audit_tool_call(request)
+
+        # Exactly one outbound request — no retry. If `_request_with_retry`
+        # ever gains a status-code-based retry that includes 401, pytest-httpx
+        # will see additional requests against the single registered response
+        # and fail.
+        assert len(httpx_mock.get_requests()) == 1
 
     @pytest.mark.asyncio
     async def test_excludes_none_fields_from_request(


### PR DESCRIPTION
## Summary

Adds an explicit regression test asserting HTTP 401 responses on `/api/v1/audit/tool-call` are terminal — the SDK never retries a 401 auth failure.

Backstops issue [getaxonflow/axonflow-enterprise#2275](https://github.com/getaxonflow/axonflow-enterprise/issues/2275), where a customer's misconfigured deployment caused a tight 401 retry loop against `community-saas` — 716 × 401 in 24 hours from a single source IP (~30/hour, not human pacing).

## Audit finding (no code change required)

Python SDK was already safe — `_request_with_retry` (axonflow/client.py:844-865) retries only on `httpx.ConnectError` / `httpx.TimeoutException`, never on HTTP status codes:

```python
@retry(
    stop=stop_after_attempt(self._config.retry.max_attempts),
    wait=wait_exponential(...),
    retry=retry_if_exception_type((httpx.ConnectError, httpx.TimeoutException)),
    reraise=True,
)
```

401 surfaces via `response.raise_for_status()` AFTER the retry loop returns, so the decorator never observes it. It's caught by the `httpx.HTTPStatusError` handler (axonflow/client.py:813-816) and re-raised as `AuthenticationError`.

## Mutation test (proves the assertion isn't tautological)

Per `feedback_mutation_test_to_prove_assertion_not_tautological.md`: temporarily injected a 401 retry loop into `_request`:

```python
if response.status_code == 401:
    for _ in range(2):
        response = await self._http_client.request(method, url, json=json_data)
```

Test result with mutation: **FAILED** — pytest-httpx caught the extra requests against the single registered response.

→ confirms `assert len(httpx_mock.get_requests()) == 1` distinguishes "401 is terminal" vs "401 retries."

## Companion work in #2275

The other 4 SDKs (Go, Rust, Java, TypeScript) get the same regression test in their respective repos. axonflow-sdk-rust PR #42 is the companion.

## Skip-runtime-e2e justification

Test-only addition; no new SDK feature surface and no wire-protocol change. The existing `runtime-e2e/` runners stay intact.

## Test plan

- [x] `pytest tests/test_audit_tool_call.py::TestAuditToolCall::test_401_not_retried_issue_2275` passes locally
- [x] Mutation test: injecting a 401 retry loop into `_request` fails the test
- [ ] CI green on this PR