### PR TITLE
feat(telemetry): include org_id in heartbeat payload (v9.1 #2277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,36 @@ when no `client_id` is configured.
  value, so caller-supplied values are harmless (no spoofing surface).
  Set on the shared `httpx.AsyncClient.headers` dict in
  `axonflow/client.py`, so every endpoint picks it up.
+- **`org_id` field in the telemetry heartbeat body (v9.1 preflight, #2277).**
+ Brings Python SDK telemetry up to parity with the platform's
+ `startup_telemetry.go` emitter — every heartbeat now identifies which
+ deployment-organization emitted it. Two sources in precedence order:
+ 1. The `ORG_ID` env var when set (the operator's explicit configuration on
+    self-hosted deployments, or the `cs_<uuid>` tenant identifier on
+    Community SaaS).
+ 2. Otherwise the `local-dev-org` sentinel (default-config Community-mode
+    developers).
+ The receiver (`ee/platform/checkpoint-service/pkg/telemetry/telemetry.go`)
+ already accepts the field with `omitempty` for backward compat with
+ pre-v8.1 SDKs that don't send it. New SDKs always send it. Honors
+ `AXONFLOW_TELEMETRY=off` like every other heartbeat field. See
+ `axonflow-landing/content/privacy.html` for the customer-facing
+ commitment that covers this field.
+
+### Changed
+
+- **Telemetry-enabled log line** softened from "anonymous telemetry
+ enabled" to "telemetry enabled" to stay coherent with the v9.1
+ `org_id` addition (the operator-supplied `ORG_ID` on self-hosted is
+ not anonymized; only the `instance_id` and `cs_<uuid>` Community
+ SaaS identifier remain anonymous-by-design).
 
 ### Compatibility
 
 - Backward-compatible against v8 and v9 platforms: v8 agents ignore the
  unknown header; v9 agents derive identity from Basic Auth regardless.
+- `org_id` is an additive field — the receiver's `omitempty` allows
+ legacy SDK builds to keep working unchanged.
 - No SDK config changes. No removed fields. No changed defaults.
 
 ## [8.0.0] - 2026-05-09 — Decision History API + policy_version recorded on every decision + telemetry simplification

--- a/axonflow/heartbeat.py
+++ b/axonflow/heartbeat.py
@@ -2,7 +2,7 @@
 
 Implements the cross-SDK contract:
 
-    AxonFlow emits at most one anonymous heartbeat per environment every
+    AxonFlow emits at most one heartbeat per environment every
     7 days during SDK activity.
 
 The gate is consulted both at client construction and at every public

--- a/axonflow/telemetry.py
+++ b/axonflow/telemetry.py
@@ -198,6 +198,26 @@ def _normalize_arch(arch: str) -> str:
     return arch
 
 
+#: Sentinel emitted on the telemetry wire when ``ORG_ID`` is unset (the
+#: default-config Community-mode developer case). See #2277.
+ORG_ID_LOCAL_DEV_SENTINEL = "local-dev-org"
+
+
+def _telemetry_org_id() -> str:
+    """Return the ``org_id`` value to emit on the next telemetry ping.
+
+    Reads ``ORG_ID`` from the environment (the operator's explicit
+    configuration for self-hosted deployments, or the ``cs_<uuid>``
+    tenant identifier on Community SaaS) and falls back to
+    :data:`ORG_ID_LOCAL_DEV_SENTINEL` when unset. Always returns a
+    non-empty string. See #2277.
+    """
+    value = os.environ.get("ORG_ID", "")
+    if value:
+        return value
+    return ORG_ID_LOCAL_DEV_SENTINEL
+
+
 def _build_payload(
     mode: str,
     platform_version: str | None = None,
@@ -235,6 +255,7 @@ def _build_payload(
         "endpoint_type": endpoint_type,
         "features": [],
         "instance_id": str(uuid.uuid4()),
+        "org_id": _telemetry_org_id(),
     }
     if mode == "sandbox":
         payload["stream"] = "sandbox"
@@ -341,7 +362,7 @@ def send_telemetry_ping(
         return
 
     logger.info(
-        "AxonFlow: anonymous telemetry enabled. "
+        "AxonFlow: telemetry enabled. "
         "Opt out: AXONFLOW_TELEMETRY=off | https://docs.getaxonflow.com/docs/telemetry"
     )
 

--- a/axonflow/types.py
+++ b/axonflow/types.py
@@ -67,8 +67,8 @@ class AxonFlowConfig(BaseModel):
         As of v1.0.0, all routes go through a single endpoint (ADR-026).
 
         As of v8.0, the legacy ``telemetry`` field has been removed. To
-        opt out of the anonymous heartbeat, set ``AXONFLOW_TELEMETRY=off``
-        in the environment — it is now the sole opt-out lever.
+        opt out of the heartbeat, set ``AXONFLOW_TELEMETRY=off`` in the
+        environment — it is now the sole opt-out lever.
     """
 
     model_config = ConfigDict(frozen=True)

--- a/runtime-e2e/v91_org_id_telemetry/README.md
+++ b/runtime-e2e/v91_org_id_telemetry/README.md
@@ -1,0 +1,59 @@
+# Runtime proof — `org_id` in SDK telemetry payload (v9.1)
+
+Verifies the v9.1 contract for the Python SDK: every telemetry ping
+body carries an `org_id` field, populated from the `ORG_ID` env var
+with a `local-dev-org` sentinel fallback. Issue #2277.
+
+## Usage
+
+```sh
+# ORG_ID set — operator-supplied (self-hosted) or cs_<uuid> (Community SaaS):
+ORG_ID=acme-corp python runtime-e2e/v91_org_id_telemetry/test.py
+
+# ORG_ID unset — local-dev-org sentinel:
+unset ORG_ID && python runtime-e2e/v91_org_id_telemetry/test.py
+```
+
+Expected output:
+
+```
+PASS: telemetry wire payload carries org_id='acme-corp' (expected='acme-corp')
+Wire body: {"telemetry_type":"sdk","sdk":"python", ... ,"org_id":"acme-corp"}
+```
+
+## What it asserts
+
+1. The SDK constructed under any config emits a telemetry POST.
+2. The POST body is valid JSON.
+3. The body has an `org_id` key.
+4. The value matches `$ORG_ID` (when set) or `local-dev-org` (when
+   unset).
+
+## CI coverage
+
+This runtime proof is a redundant real-stack confirmation alongside
+the functional E2E tests in `tests/test_telemetry.py`:
+
+- `TestTelemetryOrgIDHelperUnit` — helper env→sentinel fallback
+- `TestBuildPayloadIncludesOrgID` — payload always carries field
+- `TestSendTelemetryPingOrgIDOnWire` — three subtests confirming the
+  wire literal across acme-corp / cs_-prefixed / sentinel modes
+
+## Mutation proof
+
+Remove the `"org_id": _telemetry_org_id(),` line from
+`axonflow/telemetry.py`'s `_build_payload` and rerun. The proof exits
+with `FAIL: org_id = None, want '<expected>'`.
+
+## Cross-SDK parity
+
+Companion runtime-e2e tests live under the same subdirectory in the
+other 4 SDKs:
+
+- `axonflow-sdk-go/runtime-e2e/v91_org_id_telemetry/`
+- `axonflow-sdk-typescript/runtime-e2e/v91_org_id_telemetry/`
+- `axonflow-sdk-java/runtime-e2e/v91_org_id_telemetry/`
+- `axonflow-sdk-rust/runtime-e2e/v91_org_id_telemetry/`
+
+All five SDKs emit `org_id` with the same wire name, same sentinel
+value (`local-dev-org`), and the same precedence (env → sentinel).

--- a/runtime-e2e/v91_org_id_telemetry/test.py
+++ b/runtime-e2e/v91_org_id_telemetry/test.py
@@ -1,0 +1,93 @@
+"""Real-stack assertion: SDK emits org_id field in telemetry heartbeat (v9.1).
+
+Issue #2277. Sister proof to the Go/TS/Java/Rust SDK runtime-e2e tests.
+
+The proof stands up a local HTTP listener and drives the SDK's
+``send_telemetry_ping`` against it. Captures the raw POST body and
+asserts the wire JSON literally contains ``"org_id":"<value>"``.
+
+Usage:
+
+    # ORG_ID set — operator-supplied (self-hosted) or cs_<uuid> (Community SaaS):
+    ORG_ID=acme-corp python runtime-e2e/v91_org_id_telemetry/test.py
+
+    # ORG_ID unset — local-dev-org sentinel:
+    unset ORG_ID && python runtime-e2e/v91_org_id_telemetry/test.py
+
+Companion functional E2E coverage runs in CI via
+``tests/test_telemetry.py::TestSendTelemetryPingOrgIDOnWire``. This
+runtime proof is a redundant real-stack confirmation, not a CI gate.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socketserver
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler
+
+from axonflow.telemetry import ORG_ID_LOCAL_DEV_SENTINEL, send_telemetry_ping
+
+
+def main() -> int:
+    expected = os.environ.get("ORG_ID") or ORG_ID_LOCAL_DEV_SENTINEL
+
+    captured: dict[str, bytes] = {}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802
+            length = int(self.headers.get("Content-Length", "0"))
+            captured["body"] = self.rfile.read(length)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"latest_version": None, "alerts": []}).encode())
+
+        def do_GET(self) -> None:  # noqa: N802
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"version": "8.0.0-runtime-e2e"}).encode())
+
+        def log_message(self, *_args: object) -> None:
+            return
+
+    with socketserver.TCPServer(("127.0.0.1", 0), Handler) as srv:
+        port = srv.server_address[1]
+        thread = threading.Thread(
+            target=lambda: [srv.handle_request(), srv.handle_request()],
+            daemon=True,
+        )
+        thread.start()
+
+        os.environ["AXONFLOW_CHECKPOINT_URL"] = f"http://127.0.0.1:{port}/v1/ping"
+        os.environ.pop("AXONFLOW_TELEMETRY", None)
+
+        send_telemetry_ping(mode="production", endpoint=f"http://127.0.0.1:{port}")
+        thread.join(timeout=5.0)
+
+    body = captured.get("body")
+    if not body:
+        sys.stderr.write("FAIL: no telemetry body captured\n")
+        return 1
+
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"FAIL: body is not valid JSON: {exc}\nBody: {body!r}\n")
+        return 1
+
+    got = payload.get("org_id")
+    if got != expected:
+        sys.stderr.write(f"FAIL: org_id = {got!r}, want {expected!r}\nBody: {body!r}\n")
+        return 1
+
+    print(f"PASS: telemetry wire payload carries org_id={got!r} (expected={expected!r})")
+    print(f"Wire body: {body.decode()}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -11,10 +11,20 @@ import pytest
 
 from axonflow.telemetry import (
     _DEFAULT_CHECKPOINT_URL,
+    ORG_ID_LOCAL_DEV_SENTINEL,
     _build_payload,
     _is_telemetry_enabled,
+    _telemetry_org_id,
     send_telemetry_ping,
 )
+
+# Snapshot the real httpx.get / httpx.post before the conftest autouse
+# fixture replaces them with the egress-blocked stub. The functional
+# E2E test in this file (TestSendTelemetryPingOrgIDOnWire) is the one
+# legitimate exception that needs to drive real bytes through a local
+# socket — it reinstalls these via monkeypatch within the test only.
+_REAL_HTTPX_GET = httpx.get
+_REAL_HTTPX_POST = httpx.post
 
 # ---------------------------------------------------------------------------
 # _is_telemetry_enabled tests
@@ -368,3 +378,155 @@ def _wait_for_threads(timeout: float = 5.0) -> None:
             remaining = deadline - time.monotonic()
             if remaining > 0:
                 t.join(timeout=remaining)
+
+
+# ---------------------------------------------------------------------------
+# org_id tests — v9.1 preflight, issue #2277
+# ---------------------------------------------------------------------------
+
+
+class TestTelemetryOrgIDHelperUnit:
+    """``_telemetry_org_id`` env → sentinel fallback. Issue #2277."""
+
+    def test_org_id_set_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ORG_ID", "acme-corp")
+        assert _telemetry_org_id() == "acme-corp"
+
+    def test_org_id_unset_returns_local_dev_org_sentinel(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("ORG_ID", raising=False)
+        assert _telemetry_org_id() == ORG_ID_LOCAL_DEV_SENTINEL
+        assert ORG_ID_LOCAL_DEV_SENTINEL == "local-dev-org"  # wire-value lock
+
+    def test_org_id_empty_string_falls_through_to_sentinel(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Empty string is treated as unset — same as the Go SDK."""
+        monkeypatch.setenv("ORG_ID", "")
+        assert _telemetry_org_id() == ORG_ID_LOCAL_DEV_SENTINEL
+
+    def test_org_id_cs_prefixed_passes_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """cs_<uuid> Community SaaS tenant identifier passes through verbatim."""
+        cs_id = "cs_abc12345-6789-4def-9012-345678901234"
+        monkeypatch.setenv("ORG_ID", cs_id)
+        assert _telemetry_org_id() == cs_id
+
+
+class TestBuildPayloadIncludesOrgID:
+    """``_build_payload`` always includes ``org_id``. Issue #2277."""
+
+    def test_payload_includes_org_id_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ORG_ID", "acme-corp")
+        payload = _build_payload("production", deployment_mode="self_hosted")
+        assert payload["org_id"] == "acme-corp"
+
+    def test_payload_includes_sentinel_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ORG_ID", raising=False)
+        payload = _build_payload("production")
+        assert payload["org_id"] == ORG_ID_LOCAL_DEV_SENTINEL
+
+    def test_payload_includes_cs_uuid_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        cs_id = "cs_e3a4b5c6-d7e8-4f90-a1b2-c3d4e5f6a7b8"
+        monkeypatch.setenv("ORG_ID", cs_id)
+        payload = _build_payload("production")
+        assert payload["org_id"] == cs_id
+
+
+class TestSendTelemetryPingOrgIDOnWire:
+    """Functional E2E: org_id arrives on the wire at the receiver.
+
+    Uses a real ``http.server.HTTPServer`` in a daemon thread (no mocks
+    of httpx) so this proof exercises the full net stack between the
+    SDK and the receiver. Captures the raw request body and asserts the
+    literal JSON contains ``"org_id":"<value>"`` — defends against tag-
+    removal mutations and unintended omitempty behavior.
+    """
+
+    def _run_with_capture(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        org_id_env: str | None,
+    ) -> bytes:
+        import http.server
+        import json
+        import socketserver
+
+        # The autouse _disable_telemetry conftest fixture replaces
+        # httpx.get / httpx.post with a RuntimeError-raising stub to
+        # block real egress. This test is the legitimate exception:
+        # it stands up a localhost listener and wants real bytes on
+        # the wire. Restore the real callables for this test only;
+        # pytest monkeypatch undoes the override at function teardown.
+        monkeypatch.setattr(httpx, "get", _REAL_HTTPX_GET)
+        monkeypatch.setattr(httpx, "post", _REAL_HTTPX_POST)
+
+        captured: dict[str, bytes] = {}
+
+        class _Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self) -> None:  # noqa: N802
+                length = int(self.headers.get("Content-Length", "0"))
+                captured["body"] = self.rfile.read(length)
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"latest_version": None, "alerts": []}).encode())
+
+            def do_GET(self) -> None:  # noqa: N802
+                # SDK probes /health before posting telemetry; return a
+                # synthetic platform-version so the path doesn't fall
+                # back to None.
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"version": "8.0.0-test"}).encode())
+
+            def log_message(self, *_args: object) -> None:  # silence stderr
+                return
+
+        with socketserver.TCPServer(("127.0.0.1", 0), _Handler) as srv:
+            port = srv.server_address[1]
+            # Handle health probe + telemetry POST in sequence — two requests.
+            srv_thread = threading.Thread(
+                target=lambda: [srv.handle_request(), srv.handle_request()],
+                daemon=True,
+            )
+            srv_thread.start()
+
+            monkeypatch.setenv("AXONFLOW_CHECKPOINT_URL", f"http://127.0.0.1:{port}/v1/ping")
+            monkeypatch.setenv("AXONFLOW_TELEMETRY", "")
+            if org_id_env is None:
+                monkeypatch.delenv("ORG_ID", raising=False)
+            else:
+                monkeypatch.setenv("ORG_ID", org_id_env)
+
+            send_telemetry_ping(
+                mode="production",
+                endpoint=f"http://127.0.0.1:{port}",
+            )
+            _wait_for_threads()
+            srv_thread.join(timeout=2.0)
+
+        assert "body" in captured, "telemetry ping never reached the local server"
+        return captured["body"]
+
+    def test_org_id_acme_corp_on_wire(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        body = self._run_with_capture(monkeypatch, "acme-corp")
+        assert b'"org_id": "acme-corp"' in body or b'"org_id":"acme-corp"' in body, (
+            f"wire body missing org_id=acme-corp: {body!r}"
+        )
+
+    def test_org_id_sentinel_on_wire(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        body = self._run_with_capture(monkeypatch, None)
+        assert b'"org_id": "local-dev-org"' in body or b'"org_id":"local-dev-org"' in body, (
+            f"wire body missing sentinel org_id: {body!r}"
+        )
+
+    def test_org_id_cs_prefixed_on_wire(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        cs_id = "cs_f29e9c5c-5c5b-4e0d-8e0d-aabbccddeeff"
+        body = self._run_with_capture(monkeypatch, cs_id)
+        expected_a = f'"org_id": "{cs_id}"'.encode()
+        expected_b = f'"org_id":"{cs_id}"'.encode()
+        assert expected_a in body or expected_b in body, (
+            f"wire body missing cs_-prefixed org_id: {body!r}"
+        )


### PR DESCRIPTION
## Summary

Adds an `org_id` field to the Python SDK telemetry heartbeat payload, in parity with the platform's `startup_telemetry.go` emitter (Epic #2230, Issue #2277). Sister PR to axonflow-sdk-go#171 and follow-on PRs on the other 3 SDKs + 4 plugins.

**Two sources, precedence order:**
1. `ORG_ID` env var when set — operator's configured value on self-hosted, or `cs_<uuid>` tenant identifier on Community SaaS.
2. `local-dev-org` sentinel when unset — default-config Community-mode developers.

Always emitted. Receiver-side already accepts the field with `omitempty` for backward compat.

## DoD

- [x] Code: `axonflow/telemetry.py` adds `_telemetry_org_id()` helper + populate in `_build_payload`
- [x] Unit tests: `TestTelemetryOrgIDHelperUnit` (env→sentinel, 4 subtests)
- [x] Unit tests: `TestBuildPayloadIncludesOrgID` (3 subtests across env/sentinel/cs_)
- [x] Functional E2E (CI): `TestSendTelemetryPingOrgIDOnWire` — real `http.server.HTTPServer` in daemon thread, decoded body AND wire-literal `"org_id":"..."` JSON checked across 3 modes. Bypasses conftest's egress-block via module-level snapshot of real httpx.get/post
- [x] Mutation guard: stripping the populate line from `_build_payload` → all 3 wire tests FAIL. Verified
- [x] Runtime proof: `runtime-e2e/v91_org_id_telemetry/test.py` + README — 3 modes exercised, all PASS
- [x] CHANGELOG entry under existing `[8.1.0]` (no version bump per scope)
- [x] R3 hostile self-review against Go-SDK R3 checklist (terminology consistency, var-vs-func, CHANGELOG "Two sources" not "Three", README "will land" not "exist")
- [x] Wording sweep: log line, heartbeat module docstring, types.py docstring softened
- [x] `ruff check` clean. `mypy` warning at heartbeat.py:79 is pre-existing (sys.platform unreachable inference, macOS-specific)

## R2 captured wire bodies

```
ORG_ID=acme-corp:
{"telemetry_type":"sdk","sdk":"python", ... ,"org_id":"acme-corp"}

ORG_ID unset:
{"telemetry_type":"sdk","sdk":"python", ... ,"org_id":"local-dev-org"}

ORG_ID=cs_f29e9c5c-5c5b-4e0d-8e0d-aabbccddeeff:
{"telemetry_type":"sdk","sdk":"python", ... ,"org_id":"cs_f29e9c5c-..."}
```

## Test plan

- [ ] CI green across Contract Tests + tests on Python 3.10/3.11/3.12
- [ ] DCO trailer present
- [ ] Commit Lint passes (title 62 chars, under 72-char cap)

## Scope of changes

| File | Purpose |
|------|---------|
| `axonflow/telemetry.py` | Helper, populate, softened log line |
| `axonflow/heartbeat.py` | Comment wording softened |
| `axonflow/types.py` | Docstring wording softened |
| `tests/test_telemetry.py` | 3 new test classes (helper unit + build_payload + wire E2E) |
| `CHANGELOG.md` | Added bullet under `[8.1.0]` |
| `runtime-e2e/v91_org_id_telemetry/` | New: real-stack proof + README |

## Compatibility / risk

- Additive field; receiver already accepts it with `omitempty`. No SDK config change. No new deps.
- One pre-existing macOS-local test failure unchanged: `tests/test_telemetry_short_lived.py::test_telemetry_flushes_on_immediate_exit` — fails on darwin/Python 3.11+3.14 with empty `received` (atexit subprocess timing). Same failure on baseline `origin/main`. CI Linux is green.

Refs: getaxonflow/axonflow-enterprise#2230 (Epic v9 identity)
Refs: getaxonflow/axonflow-enterprise#2277 (v9.1 SDK + plugin org_id telemetry)