### PR TITLE
chore: update CHANGELOG release date to 2026-05-22 [skip-runtime-e2e]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  and tag v{X.Y.Z}. The release workflow's preflight checks the section
  header matches the tag. -->
 
-## [8.1.0] - 2026-05-19 — `X-Client-ID` header on every outbound request + `org_id` in telemetry heartbeat
+## [8.1.0] - 2026-05-22 — `X-Client-ID` header on every outbound request + `org_id` in telemetry heartbeat
 
 Companion release to the v9 identity cleanup on the platform. Every
 governed request now carries an `X-Client-ID: <effective_client_id>`


### PR DESCRIPTION
## Summary

- Updates the topmost release-line section date header to `2026-05-22` (the actual release day) to match the coordinated v8.0.0 release-day sweep across the AxonFlow repos.
- One-line date-only change; no content edits.

## Skip-runtime-e2e justification

Pure documentation change — only `CHANGELOG.md` is touched. No runtime binary, SDK, or agent code path changes. No env-var defaults, wire shape, or feature behavior affected. No runtime feature surface exists for runtime-e2e to exercise.

## Test plan

- [x] No-internal-refs grep audit on added lines: zero hits.
- [x] One-line diff (date only).