### PR TITLE
feat(indonesia): pii-indonesia + cross-border audit fields [skip-runtime-e2e]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  and tag v{X.Y.Z}. The release workflow's preflight checks the section
  header matches the tag. -->
 
+## [Unreleased]
+
+### Added
+
+- **`PolicyCategory.PII_INDONESIA` constant** (`"pii-indonesia"`).
+  Enables filtering and creating policies for Indonesian PII detection
+  (NIK, KK, NPWP, BPJS) alongside the existing per-jurisdiction categories.
+- **`data_residency` and `transfer_basis` fields on `AuditLogEntry`.**
+  Optional string fields supporting cross-border data transfer logging.
+  `data_residency` is an ISO 3166-1 alpha-2 country code;
+  `transfer_basis` is one of `adequacy`, `safeguards`, or `consent`.
+  Both default to `None` for backward compatibility with older platform versions.
+- **Indonesia compliance example** (`examples/indonesia_compliance.py`):
+  demonstrates NIK detection, audit log querying with cross-border fields,
+  and policy filtering by the new `pii-indonesia` category.
+
 ## [8.2.0] - 2026-05-23 — `create_hitl_request` for explicit HITL row creation
 
 Enables agent-framework plugins (Google ADK, n8n, OpenAI Agents SDK) to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  and tag v{X.Y.Z}. The release workflow's preflight checks the section
  header matches the tag. -->
 
-## [Unreleased]
+## [8.3.0] - 2026-05-26 — Indonesia PII category + cross-border audit fields
 
 ### Added
 

--- a/axonflow/_version.py
+++ b/axonflow/_version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the AxonFlow SDK version."""
 
-__version__ = "8.2.0"
+__version__ = "8.3.0"

--- a/axonflow/policies.py
+++ b/axonflow/policies.py
@@ -29,6 +29,7 @@ class PolicyCategory(str, Enum):
     PII_EU = "pii-eu"
     PII_INDIA = "pii-india"
     PII_SINGAPORE = "pii-singapore"
+    PII_INDONESIA = "pii-indonesia"
 
     # Static policy categories - Code Governance
     CODE_SECRETS = "code-secrets"

--- a/axonflow/types.py
+++ b/axonflow/types.py
@@ -827,6 +827,8 @@ class AuditLogEntry(BaseModel):
     latency_ms: int = Field(default=0, ge=0, description="Latency in ms")
     policy_violations: list[str] = Field(default_factory=list, description="Violated policies")
     metadata: dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
+    data_residency: str | None = Field(default=None, description="ISO 3166-1 alpha-2 country code for data storage location")
+    transfer_basis: str | None = Field(default=None, description="Legal basis for cross-border transfer: adequacy, safeguards, or consent")
 
 
 class AuditSearchResponse(BaseModel):

--- a/axonflow/types.py
+++ b/axonflow/types.py
@@ -827,8 +827,12 @@ class AuditLogEntry(BaseModel):
     latency_ms: int = Field(default=0, ge=0, description="Latency in ms")
     policy_violations: list[str] = Field(default_factory=list, description="Violated policies")
     metadata: dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
-    data_residency: str | None = Field(default=None, description="ISO 3166-1 alpha-2 country code for data storage location")
-    transfer_basis: str | None = Field(default=None, description="Legal basis for cross-border transfer: adequacy, safeguards, or consent")
+    data_residency: str | None = Field(
+        default=None, description="ISO 3166-1 alpha-2 data residency code"
+    )
+    transfer_basis: str | None = Field(
+        default=None, description="Cross-border transfer legal basis"
+    )
 
 
 class AuditSearchResponse(BaseModel):

--- a/examples/indonesia_compliance.py
+++ b/examples/indonesia_compliance.py
@@ -1,0 +1,88 @@
+"""Indonesia Compliance Example.
+
+Demonstrates Indonesian PII detection (NIK), audit log querying with
+cross-border data transfer fields, and policy filtering by the
+pii-indonesia category.
+
+Requirements:
+    pip install axonflow
+    export AXONFLOW_AGENT_URL=http://localhost:8080
+    export AXONFLOW_CLIENT_ID=your-client-id
+    export AXONFLOW_CLIENT_SECRET=your-client-secret
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from axonflow import AxonFlow
+from axonflow.policies import PolicyCategory
+
+
+async def main() -> None:
+    agent_url = os.environ.get("AXONFLOW_AGENT_URL", "http://localhost:8080")
+    client_id = os.environ.get("AXONFLOW_CLIENT_ID", "")
+    client_secret = os.environ.get("AXONFLOW_CLIENT_SECRET", "")
+
+    if not client_id or not client_secret:
+        raise SystemExit("AXONFLOW_CLIENT_ID and AXONFLOW_CLIENT_SECRET must be set")
+
+    client = AxonFlow(
+        agent_url=agent_url,
+        client_id=client_id,
+        client_secret=client_secret,
+    )
+
+    print("=== Indonesia Compliance Example ===\n")
+
+    # 1. Verify PII Indonesia category constant
+    print(f"PII Indonesia category: {PolicyCategory.PII_INDONESIA.value}")
+
+    # 2. Send a request containing an Indonesian NIK
+    print("\nSending governed request with NIK...")
+    try:
+        resp = await client.proxy_llm_call(
+            user_token="",
+            query="Customer NIK is 3204110507900003 and their name is Budi Santoso",
+            request_type="chat",
+            context={"purpose": "identity_verification"},
+        )
+        print(f"Response blocked: {resp.blocked}")
+        if resp.policy_info:
+            print(f"Policies evaluated: {resp.policy_info.policies_evaluated}")
+    except Exception as e:
+        print(f"Request error (expected if no LLM configured): {e}")
+
+    # 3. Query audit logs to demonstrate cross-border fields
+    print("\nQuerying audit logs...")
+    try:
+        audit_resp = await client.search_audit_logs(limit=5)
+        print(f"Found {len(audit_resp.entries)} audit entries")
+        for entry in audit_resp.entries:
+            line = f"  [{entry.timestamp}] type={entry.request_type} blocked={entry.blocked}"
+            if entry.data_residency:
+                line += f" residency={entry.data_residency}"
+            if entry.transfer_basis:
+                line += f" basis={entry.transfer_basis}"
+            print(line)
+    except Exception as e:
+        print(f"Audit search error: {e}")
+
+    # 4. List policies filtered by Indonesia PII category
+    print("\nListing Indonesia PII policies...")
+    try:
+        policies = await client.list_static_policies(
+            category=PolicyCategory.PII_INDONESIA,
+        )
+        print(f"Found {len(policies)} Indonesia PII policies")
+        for p in policies:
+            print(f"  {p.name}: {p.description} (severity={p.severity}, action={p.action})")
+    except Exception as e:
+        print(f"Policy list error: {e}")
+
+    print("\n=== Done ===")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/indonesia_compliance.py
+++ b/examples/indonesia_compliance.py
@@ -17,6 +17,7 @@ import asyncio
 import os
 
 from axonflow import AxonFlow
+from axonflow.exceptions import AxonFlowError
 from axonflow.policies import PolicyCategory
 
 
@@ -25,8 +26,9 @@ async def main() -> None:
     client_id = os.environ.get("AXONFLOW_CLIENT_ID", "")
     client_secret = os.environ.get("AXONFLOW_CLIENT_SECRET", "")
 
+    msg = "AXONFLOW_CLIENT_ID and AXONFLOW_CLIENT_SECRET must be set"
     if not client_id or not client_secret:
-        raise SystemExit("AXONFLOW_CLIENT_ID and AXONFLOW_CLIENT_SECRET must be set")
+        raise SystemExit(msg)
 
     client = AxonFlow(
         agent_url=agent_url,
@@ -51,7 +53,7 @@ async def main() -> None:
         print(f"Response blocked: {resp.blocked}")
         if resp.policy_info:
             print(f"Policies evaluated: {resp.policy_info.policies_evaluated}")
-    except Exception as e:
+    except AxonFlowError as e:
         print(f"Request error (expected if no LLM configured): {e}")
 
     # 3. Query audit logs to demonstrate cross-border fields
@@ -66,7 +68,7 @@ async def main() -> None:
             if entry.transfer_basis:
                 line += f" basis={entry.transfer_basis}"
             print(line)
-    except Exception as e:
+    except AxonFlowError as e:
         print(f"Audit search error: {e}")
 
     # 4. List policies filtered by Indonesia PII category
@@ -78,7 +80,7 @@ async def main() -> None:
         print(f"Found {len(policies)} Indonesia PII policies")
         for p in policies:
             print(f"  {p.name}: {p.description} (severity={p.severity}, action={p.action})")
-    except Exception as e:
+    except AxonFlowError as e:
         print(f"Policy list error: {e}")
 
     print("\n=== Done ===")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "axonflow"
-version = "8.2.0"
+version = "8.3.0"
 description = "AxonFlow Python SDK - Enterprise AI Governance in 3 Lines of Code"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/fixtures/wire_shape_baseline.json
+++ b/tests/fixtures/wire_shape_baseline.json
@@ -182,9 +182,11 @@
     "AuditLogEntry": {
       "note": "spec-bug-pending: #1745 \u2014 agent-api.yaml AuditLogEntry omits metadata/model/policy_violations the agent emits on every audit-log read.",
       "sdk_only": [
+        "data_residency",
         "metadata",
         "model",
-        "policy_violations"
+        "policy_violations",
+        "transfer_basis"
       ],
       "spec_only": []
     },

--- a/tests/test_indonesia_pii_audit.py
+++ b/tests/test_indonesia_pii_audit.py
@@ -1,0 +1,101 @@
+"""Tests for Indonesia PII category constant and cross-border audit fields."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from axonflow.policies import PolicyCategory
+from axonflow.types import AuditLogEntry
+
+
+class TestPIIIndonesiaCategory:
+    def test_constant_value(self) -> None:
+        assert PolicyCategory.PII_INDONESIA.value == "pii-indonesia"
+
+    def test_is_valid_enum_member(self) -> None:
+        assert PolicyCategory("pii-indonesia") is PolicyCategory.PII_INDONESIA
+
+    def test_string_representation(self) -> None:
+        assert str(PolicyCategory.PII_INDONESIA) == "PolicyCategory.PII_INDONESIA"
+
+    def test_alongside_other_pii_categories(self) -> None:
+        pii_categories = [
+            PolicyCategory.PII_GLOBAL,
+            PolicyCategory.PII_US,
+            PolicyCategory.PII_EU,
+            PolicyCategory.PII_INDIA,
+            PolicyCategory.PII_SINGAPORE,
+            PolicyCategory.PII_INDONESIA,
+        ]
+        values = [c.value for c in pii_categories]
+        assert "pii-indonesia" in values
+        assert len(set(values)) == len(values)
+
+
+class TestAuditLogEntryCrossBorderFields:
+    def test_fields_populated(self) -> None:
+        entry = AuditLogEntry(
+            id="aud-001",
+            request_id="req-001",
+            timestamp=datetime(2026, 5, 26, 10, 0, 0, tzinfo=timezone.utc),
+            user_email="analyst@bank.co.id",
+            data_residency="ID",
+            transfer_basis="adequacy",
+        )
+        assert entry.data_residency == "ID"
+        assert entry.transfer_basis == "adequacy"
+
+    def test_fields_from_dict(self) -> None:
+        data = {
+            "id": "aud-002",
+            "timestamp": "2026-05-26T10:00:00Z",
+            "data_residency": "ID",
+            "transfer_basis": "safeguards",
+        }
+        entry = AuditLogEntry.model_validate(data)
+        assert entry.data_residency == "ID"
+        assert entry.transfer_basis == "safeguards"
+
+    def test_backward_compat_fields_absent(self) -> None:
+        data = {
+            "id": "aud-003",
+            "timestamp": "2026-05-26T10:00:00Z",
+            "user_email": "user@company.com",
+            "success": True,
+            "blocked": False,
+        }
+        entry = AuditLogEntry.model_validate(data)
+        assert entry.data_residency is None
+        assert entry.transfer_basis is None
+
+    def test_serialization_omits_none(self) -> None:
+        entry = AuditLogEntry(
+            id="aud-004",
+            timestamp=datetime(2026, 5, 26, 10, 0, 0, tzinfo=timezone.utc),
+        )
+        data = entry.model_dump(exclude_none=True)
+        assert "data_residency" not in data
+        assert "transfer_basis" not in data
+
+    def test_serialization_includes_when_set(self) -> None:
+        entry = AuditLogEntry(
+            id="aud-005",
+            timestamp=datetime(2026, 5, 26, 10, 0, 0, tzinfo=timezone.utc),
+            data_residency="SG",
+            transfer_basis="consent",
+        )
+        data = entry.model_dump()
+        assert data["data_residency"] == "SG"
+        assert data["transfer_basis"] == "consent"
+
+    def test_json_round_trip(self) -> None:
+        entry = AuditLogEntry(
+            id="aud-006",
+            timestamp=datetime(2026, 5, 26, 10, 0, 0, tzinfo=timezone.utc),
+            data_residency="ID",
+            transfer_basis="adequacy",
+        )
+        json_str = entry.model_dump_json()
+        restored = AuditLogEntry.model_validate_json(json_str)
+        assert restored.data_residency == "ID"
+        assert restored.transfer_basis == "adequacy"


### PR DESCRIPTION
## Summary

- Add `PolicyCategory.PII_INDONESIA` constant (`"pii-indonesia"`) for Indonesian PII detection (NIK, KK, NPWP, BPJS)
- Add `data_residency` and `transfer_basis` optional fields to `AuditLogEntry` for cross-border data transfer logging
- Add Indonesia compliance example (`examples/indonesia_compliance.py`)

## Cross-SDK parity

Part of a 5-SDK sweep (Go/Python/TypeScript/Java/Rust). JSON wire values are identical across all SDKs:
- Policy category: `"pii-indonesia"`
- Audit fields: `data_residency` (ISO 3166-1 alpha-2), `transfer_basis` (adequacy|safeguards|consent)

## Skip-runtime-e2e justification

New fields (`data_residency`, `transfer_basis`) are additive optional fields on `AuditLogEntry` — they default to `None` and deserialize from existing platform responses without error. The `pii-indonesia` category constant is a string enum value following the existing pattern. No runtime-e2e is possible until the platform ships the corresponding validators.

## Test plan

- [x] `pytest tests/test_indonesia_pii_audit.py` — 10 tests pass
- [x] Full suite: 1003 passed, 29 skipped, coverage 81.46%
- [x] Backward compat: entries without new fields deserialize to None
- [x] Serialization: None fields omitted from output
- [x] Example syntax validated

Tracking: getaxonflow/axonflow-enterprise#2478