### PR TITLE
chore(contract): bump OpenAPI spec pin to community v9.13.0

### DIFF
--- a/tests/fixtures/wire_shape_baseline.json
+++ b/tests/fixtures/wire_shape_baseline.json
@@ -11,39 +11,19 @@
         "error"
       ]
     },
-    "BiasRecord": {
+    "CreateOverrideRequest": {
       "agent-api.yaml": [
-        "category",
-        "group_a",
-        "group_a_rate",
-        "group_b",
-        "group_b_rate",
-        "id",
-        "is_violation",
-        "model_id",
-        "org_id",
-        "sample_size",
-        "score",
-        "threshold",
-        "timestamp"
+        "action_override",
+        "enabled_override",
+        "expires_at",
+        "override_reason"
       ],
       "orchestrator-api.yaml": [
-        "category",
-        "group_a",
-        "group_a_rate",
-        "group_b",
-        "group_b_rate",
-        "id",
-        "is_violation",
-        "metadata",
-        "model_id",
-        "org_id",
-        "sample_size",
-        "score",
-        "threshold",
-        "timestamp",
-        "window_end",
-        "window_start"
+        "override_reason",
+        "policy_id",
+        "policy_type",
+        "tool_signature",
+        "ttl_seconds"
       ]
     },
     "CreatePolicyRequest": {
@@ -63,40 +43,80 @@
       ],
       "policy-api.yaml": [
         "actions",
+        "category",
         "conditions",
         "description",
         "enabled",
         "name",
         "priority",
+        "tags",
+        "tier",
         "type"
       ]
     },
-    "EUAIActExportRequest": {
+    "DecisionExplanation": {
       "agent-api.yaml": [
-        "format",
-        "from_date",
-        "include_accuracy_metrics",
-        "include_assessments",
-        "include_bias_records",
-        "include_decision_chains",
-        "include_hitl_records",
-        "org_id",
-        "to_date"
+        "decision",
+        "decision_id",
+        "historical_hit_count_session",
+        "matched_rules",
+        "override_available",
+        "override_existing_id",
+        "policy_matches",
+        "policy_source_link",
+        "reason",
+        "risk_level",
+        "timestamp",
+        "tool_signature"
       ],
       "orchestrator-api.yaml": [
-        "date_from",
-        "date_to",
-        "export_type",
-        "format",
-        "model_ids"
+        "context",
+        "context_truncated",
+        "decision",
+        "decision_id",
+        "historical_hit_count_session",
+        "latest_policy_version",
+        "matched_rules",
+        "override_available",
+        "override_existing_id",
+        "policy_matches",
+        "policy_source_link",
+        "policy_version_at_decision",
+        "reason",
+        "risk_level",
+        "timestamp",
+        "tool_signature"
+      ]
+    },
+    "Finding": {
+      "masfeat-api.yaml": [
+        "category",
+        "description",
+        "due_date",
+        "id",
+        "pillar",
+        "remediation",
+        "severity",
+        "status"
+      ],
+      "orchestrator-api.yaml": [
+        "article",
+        "category",
+        "description",
+        "id",
+        "remediation",
+        "severity",
+        "status"
       ]
     },
     "HealthResponse": {
       "agent-api.yaml": [
         "capabilities",
+        "plugin_compatibility",
         "sdk_compatibility",
         "service",
         "status",
+        "tier",
         "timestamp",
         "version"
       ],
@@ -104,6 +124,7 @@
         "capabilities",
         "components",
         "features",
+        "plugin_compatibility",
         "sdk_compatibility",
         "service",
         "status",
@@ -127,33 +148,6 @@
         "timestamp"
       ]
     },
-    "PolicyOverride": {
-      "agent-api.yaml": [
-        "action_override",
-        "created_at",
-        "created_by",
-        "enabled_override",
-        "expires_at",
-        "id",
-        "organization_id",
-        "override_reason",
-        "policy_id",
-        "policy_type",
-        "tenant_id",
-        "updated_at",
-        "updated_by"
-      ],
-      "policy-api.yaml": [
-        "action_override",
-        "created_at",
-        "created_by",
-        "enabled_override",
-        "expires_at",
-        "id",
-        "override_reason",
-        "policy_id"
-      ]
-    },
     "UpdatePolicyRequest": {
       "orchestrator-api.yaml": [
         "action",
@@ -168,145 +162,102 @@
       ],
       "policy-api.yaml": [
         "actions",
+        "category",
         "conditions",
         "description",
         "enabled",
         "name",
         "priority",
+        "tags",
         "type"
       ]
     }
   },
-  "openapi_specs_sha": "0bd9256237ebbffb9c0101126da71f2c940a1695",
+  "openapi_specs_sha": "df027c788b60c18d044278c45aa4bce3a1ac8717",
   "per_model_drift": {
     "AISystemRegistry": {
-      "note": "acknowledged-sdk-superset: getaxonflow/axonflow-enterprise#3254 pin-advance batch (dataclass binding, #3262) - the parser reads the REAL server wire names (platform/orchestrator/masfeat/types.go at v9.13.0) ahead of this fiction-era spec pin, which still declares the legacy shape. Resolves when the pin advances to v9.13.0 (PR #214), where the legacy spellings the parser reads first-for-compatibility become the sdk_only set instead. owner_email/risk_rating_impact/risk_rating_complexity/risk_rating_reliance are the real wire names read as fallbacks behind the legacy business_owner/customer_impact/model_complexity/human_reliance spellings; technical_owner is deprecated fiction (never served on 9.x).",
+      "note": "deprecated-pending-removal: getaxonflow/axonflow-enterprise#3254 pin-advance batch (dataclass binding, #3262). sdk_only lists the LEGACY spellings the parser reads first-for-compatibility before falling back to the real v9.13.0 wire names (now spec-declared), here business_owner/customer_impact/model_complexity/human_reliance (real wire: owner_email/risk_rating_impact/risk_rating_complexity/risk_rating_reliance), plus deprecated fiction technical_owner (never served on 9.x). spec_only fields (data_sources/model_type/version/deployment_date/last_assessment_date/next_assessment_due/updated_by) are informational coverage gaps (PR #224). Legacy spellings burn down in the next major.",
       "sdk_only": [
-        "owner_email",
-        "risk_rating_complexity",
-        "risk_rating_impact",
-        "risk_rating_reliance"
+        "business_owner",
+        "customer_impact",
+        "human_reliance",
+        "model_complexity",
+        "technical_owner"
       ],
-      "spec_only": []
+      "spec_only": [
+        "data_sources",
+        "deployment_date",
+        "last_assessment_date",
+        "model_type",
+        "next_assessment_due",
+        "updated_by",
+        "version"
+      ]
     },
     "AuditLogEntry": {
-      "note": "spec-bug-pending: #1745 \u2014 agent-api.yaml AuditLogEntry omits metadata/model/policy_violations the agent emits on every audit-log read. Plus getaxonflow/axonflow-enterprise#3254 additive interim: policy_decision/policy_details/response_time_ms are the REAL 9.x wire fields (platform/orchestrator/audit_logger.go AuditEntry serves them at v9.6.1 and v9.13.0); this pre-v9 spec pin predates them, so they read as sdk_only until the pin moves to v9.13.0 (PR #214).",
+      "note": "deprecated-pending-removal: getaxonflow/axonflow-enterprise#3254 additive interim. The seven sdk_only fields (blocked/success/risk_score/latency_ms/query_summary/policy_violations/metadata) were NEVER served on the 9.x line - the v9.6.1-era spec described a fiction shape and the v9.13.0 spec sync corrected it to the real audit_logger.go AuditEntry struct. They are deprecated on the SDK model (PR #223), keep parsing to defaults, and burn down in the coordinated four-SDK next major per the #3254 operator decision. The real wire fields policy_decision/policy_details/response_time_ms are modeled since PR #223 and now match the spec. spec_only: 15 real wire fields the SDK does not yet model (query/query_hash, user_id/user_role/org_id, cost, error_message, correlation_id/session_id/plane/decision_id, redacted_fields/response_sample/compliance_flags/security_metrics) - a read-side coverage gap, not a break; candidates for the next-major audit model rewrite.",
       "sdk_only": [
-        "data_residency",
+        "blocked",
+        "latency_ms",
         "metadata",
-        "model",
-        "policy_decision",
-        "policy_details",
         "policy_violations",
-        "response_time_ms",
-        "transfer_basis"
+        "query_summary",
+        "risk_score",
+        "success"
       ],
-      "spec_only": []
+      "spec_only": [
+        "compliance_flags",
+        "correlation_id",
+        "cost",
+        "decision_id",
+        "error_message",
+        "org_id",
+        "plane",
+        "query",
+        "query_hash",
+        "redacted_fields",
+        "response_sample",
+        "security_metrics",
+        "session_id",
+        "user_id",
+        "user_role"
+      ]
     },
     "AuditSearchRequest": {
-      "note": "acknowledged-sdk-superset: tracked in #1745. SDK accepts decision_id/offset/override_id/policy_name as query params; agent-api.yaml AuditSearchRequest doesn't yet declare them. Plus getaxonflow/axonflow-enterprise#3254: `action` is the search filter the 9.x server actually reads (audit_read_handlers.go); this pre-v9 spec pin predates it, so it reads as sdk_only until the pin moves to v9.13.0 (PR #214).",
+      "note": "deprecated-pending-removal: getaxonflow/axonflow-enterprise#3254. sdk_only `request_type` is not read as a search filter by the 9.x server (a search filtered only by it silently returns unfiltered results - proven by the session-3254 live capture); deprecated on the search request (PR #223), still sent when set (harmless, ignored), removed in the next major. The real filter `action` is modeled since PR #223 and matches the spec. spec_only `session_id`: filter declared by the v9.13.0 spec, not yet modeled - coverage gap, not a break.",
       "sdk_only": [
-        "action",
-        "decision_id",
-        "offset",
-        "override_id",
-        "policy_name"
+        "request_type"
       ],
-      "spec_only": []
+      "spec_only": [
+        "session_id"
+      ]
     },
-    "AuditToolCallRequest": {
-      "note": "acknowledged-sdk-superset: tracked in getaxonflow/axonflow-enterprise#2912. SDK declares caller_name; platform accepts/writes it (PR #2953) but the community OpenAPI spec has not caught up yet.",
+    "DecideResponse": {
+      "note": "acknowledged-sdk-superset: tracked in #1745. SDK declares `error`; the agent's decide error envelope (sendDecideError) emits it alongside verdict=deny on malformed requests so PEP code parses a single envelope, but agent-api.yaml DecideResponse doesn't yet declare it.",
       "sdk_only": [
-        "caller_name"
-      ],
-      "spec_only": []
-    },
-    "Budget": {
-      "note": "acknowledged-sdk-superset: tracked in #1745. SDK declares `enabled`; platform emits it but spec doesn't yet declare it.",
-      "sdk_only": [
-        "enabled"
-      ],
-      "spec_only": []
-    },
-    "CancelPlanResponse": {
-      "note": "acknowledged-sdk-superset: tracked in #1745. SDK declares `message`; platform emits it but spec doesn't yet declare it.",
-      "sdk_only": [
-        "message"
-      ],
-      "spec_only": []
-    },
-    "ClientRequest": {
-      "note": "acknowledged-sdk-superset: tracked in #1745. SDK declares `media` on the request; the platform's multimodal governance code path consumes it but the request schema in the spec doesn't yet declare it.",
-      "sdk_only": [
-        "media"
-      ],
-      "spec_only": []
-    },
-    "ClientResponse": {
-      "note": "acknowledged-sdk-superset: tracked in #1745. SDK declares `budget_info` (Issue #1082) and `media_analysis` on the response; the platform emits both but the spec doesn't yet declare them.",
-      "sdk_only": [
-        "budget_info",
-        "media_analysis"
-      ],
-      "spec_only": []
-    },
-    "CreateStaticPolicyRequest": {
-      "note": "acknowledged-sdk-superset: tracked in #1745. SDK accepts `organization_id` for org-tier policies (Enterprise); spec doesn't yet declare it on the request schema.",
-      "sdk_only": [
-        "organization_id"
-      ],
-      "spec_only": []
-    },
-    "CreateWorkflowResponse": {
-      "note": "acknowledged-sdk-superset: tracked in #1745. SDK declares `created_at`/`source`; platform emits both but spec doesn't yet declare them.",
-      "sdk_only": [
-        "created_at",
-        "source"
+        "error"
       ],
       "spec_only": []
     },
     "DecisionExplanation": {
-      "note": "acknowledged-sdk-superset: context + context_truncated are surfaced by the SDK ahead of the OpenAPI spec (platform #2509 / epic #2508); the spec will declare them in the v8.5.0 sync.",
-      "sdk_only": [
-        "context",
-        "context_truncated"
-      ],
-      "spec_only": []
+      "note": "acknowledged-spec-superset: the former sdk_only context/context_truncated entries resolved - the v9.13.0 spec declares them (platform #2509 / epic #2508). spec_only latest_policy_version/policy_version_at_decision (policy-version pinning surface) are declared by v9.13.0 but not yet modeled - additive, no break.",
+      "sdk_only": [],
+      "spec_only": [
+        "latest_policy_version",
+        "policy_version_at_decision"
+      ]
     },
-    "DynamicPolicy": {
-      "note": "spec-bug-pending: #1745 \u2014 policy-api.yaml DynamicPolicy omits 7 fields (category, created_at, organization_id, priority, tier, type, updated_at) every policy-CRUD caller needs.",
-      "sdk_only": [
-        "category",
-        "created_at",
-        "organization_id",
-        "priority",
-        "tier",
-        "type",
-        "updated_at"
-      ],
-      "spec_only": []
+    "DecisionTarget": {
+      "note": "acknowledged-spec-superset: the v9.13.0 spec declares optional `server` on DecisionTarget (two-field (server, tool) identity contract, epic #2905 / platform #2904); the SDK does not yet model it there - additive optional, no break.",
+      "sdk_only": [],
+      "spec_only": [
+        "server"
+      ]
     },
     "DynamicPolicyMatch": {
       "note": "deprecated-pending-removal: `reason` is marked DEPRECATED + 'Removed in v7' on its Field() docstring; the canonical wire field is `message` (already present, matches spec).",
       "sdk_only": [
         "reason"
-      ],
-      "spec_only": []
-    },
-    "ExecutionSnapshot": {
-      "note": "acknowledged-sdk-superset: tracked in #1745. SDK declares `approval_required`/`approved_at`/`approved_by`; platform emits these in HITL flows but spec doesn't yet declare them.",
-      "sdk_only": [
-        "approval_required",
-        "approved_at",
-        "approved_by"
-      ],
-      "spec_only": []
-    },
-    "ExecutionSummary": {
-      "note": "acknowledged-sdk-superset: tracked in #1745. SDK declares `input_summary`/`output_summary`; platform emits both but spec doesn't yet declare them.",
-      "sdk_only": [
-        "input_summary",
-        "output_summary"
       ],
       "spec_only": []
     },
@@ -317,65 +268,31 @@
       ],
       "spec_only": []
     },
+    "HITLApprovalRequest": {
+      "note": "acknowledged-spec-superset: the v9.13.0 spec declares id/override_authorized_by/override_justification/reviewer_role on HITLApprovalRequest; the SDK does not yet model them - additive server-side surface, no break. Newly registered by the v9.13.0 pin.",
+      "sdk_only": [],
+      "spec_only": [
+        "id",
+        "override_authorized_by",
+        "override_justification",
+        "reviewer_role"
+      ]
+    },
     "KillSwitch": {
-      "note": "acknowledged-sdk-superset: getaxonflow/axonflow-enterprise#3254 pin-advance batch (dataclass binding, #3262) - the parser reads the REAL server wire names (platform/orchestrator/masfeat/types.go at v9.13.0) ahead of this fiction-era spec pin, which still declares the legacy shape. Resolves when the pin advances to v9.13.0 (PR #214), where the legacy spellings the parser reads first-for-compatibility become the sdk_only set instead. triggered_reason is the legacy first-choice read; trigger_reason (masfeat/types.go:288) is the real wire name.",
+      "note": "deprecated-pending-removal: getaxonflow/axonflow-enterprise#3254 pin-advance batch (dataclass binding, #3262). sdk_only lists the LEGACY spellings the parser reads first-for-compatibility before falling back to the real v9.13.0 wire names (now spec-declared), here triggered_reason (real wire: trigger_reason, masfeat/types.go:288). spec_only trigger_conditions/restore_reason are informational coverage gaps, not modeled (stated in PR #224). Legacy spelling burns down in the next major.",
       "sdk_only": [
-        "trigger_reason"
+        "triggered_reason"
       ],
-      "spec_only": []
-    },
-    "MCPCheckInputRequest": {
-      "note": "acknowledged-sdk-superset: tracked in #2563/#2571 \u2014 SDK declares `content_type` (request-redaction detector selector, ADR-056); the agent consumes it on POST /api/v1/mcp/check-input but agent-api.yaml doesn't yet declare it. Also declares `tool` (epic #2905, platform sub-issue #2904) \u2014 the two-field (server, tool) identity contract; #2904 merged to axonflow-enterprise (c8df2006b) and first released in platform v9.10.0, so this drift just tracks the pinned OpenAPI spec (agent-api.yaml) catching up.",
-      "sdk_only": [
-        "content_type",
-        "tool"
-      ],
-      "spec_only": []
-    },
-    "MCPCheckInputResponse": {
-      "note": "acknowledged-sdk-superset: tracked in #2563/#2571 \u2014 SDK declares `redacted`/`redacted_statement`/`redaction_evaluated`; the agent emits them on every evaluated check-input allow path (engine-fulfillable redact_pii obligations, ADR-056). Verified live against an enterprise agent.",
-      "sdk_only": [
-        "redacted",
-        "redacted_statement",
-        "redaction_evaluated"
-      ],
-      "spec_only": []
-    },
-    "MCPCheckOutputRequest": {
-      "note": "acknowledged-sdk-superset: tracked in epic #2905, platform sub-issue #2904 \u2014 SDK declares `tool`, mirroring MCPCheckInputRequest.tool for the two-field (server, tool) identity contract. Unlike the input-phase field, the platform's MCPCheckOutputRequest has no matching `tool` field on any released version yet (tracked by #2955) \u2014 sending it is forward-compatible and harmless but not yet consumed server-side.",
-      "sdk_only": [
-        "tool"
-      ],
-      "spec_only": []
+      "spec_only": [
+        "restore_reason",
+        "trigger_conditions"
+      ]
     },
     "MCPCheckOutputResponse": {
-      "note": "acknowledged-sdk-superset: tracked in #2563/#2571 \u2014 SDK declares `redaction_evaluated` for response-phase obligation fail-closed parity with check-input (ADR-056); platform predates the field on check-output, so it defaults False.",
+      "note": "acknowledged-sdk-superset: the former `redaction_evaluated` entry resolved - the v9.13.0 spec declares it (#2865/#2866). SDK still declares decision-context fields `policy_matches`/`redacted_message` (Plugin Batch 1, v7.1.0 cycle) ahead of the spec; tracked in #1745.",
       "sdk_only": [
-        "redaction_evaluated"
-      ],
-      "spec_only": []
-    },
-    "MarkStepCompletedRequest": {
-      "note": "acknowledged-sdk-superset: tracked in #1745. SDK accepts `metadata` on step-completed; platform reads it but spec doesn't yet declare it.",
-      "sdk_only": [
-        "metadata"
-      ],
-      "spec_only": []
-    },
-    "PlanResponse": {
-      "note": "spec-bug-pending: #1745 \u2014 orchestrator-api.yaml PlanResponse omits complexity/domain/parallel/status returned from every generate_plan call.",
-      "sdk_only": [
-        "complexity",
-        "domain",
-        "parallel",
-        "status"
-      ],
-      "spec_only": []
-    },
-    "PolicyEvaluationInfo": {
-      "note": "acknowledged-sdk-superset: tracked in #1745. SDK declares `code_artifact` on the policy_info block; the platform's code-governance path emits it but the spec doesn't yet declare it.",
-      "sdk_only": [
-        "code_artifact"
+        "policy_matches",
+        "redacted_message"
       ],
       "spec_only": []
     },
@@ -384,7 +301,13 @@
       "sdk_only": [
         "active"
       ],
-      "spec_only": []
+      "spec_only": [
+        "organization_id",
+        "policy_type",
+        "tenant_id",
+        "updated_at",
+        "updated_by"
+      ]
     },
     "PolicyVersion": {
       "note": "deprecated-pending-removal: `change_description`, `new_values`, `previous_values` are each marked DEPRECATED + 'Removed in v7' on their Field() docstrings; the canonical wire fields are `change_summary` + `snapshot` (already present, match spec).",
@@ -396,74 +319,32 @@
       "spec_only": []
     },
     "RegistrySummary": {
-      "note": "acknowledged-sdk-superset: getaxonflow/axonflow-enterprise#3254 pin-advance batch (dataclass binding, #3262) - the parser reads the REAL server wire names (platform/orchestrator/masfeat/types.go at v9.13.0) ahead of this fiction-era spec pin, which still declares the legacy shape. Resolves when the pin advances to v9.13.0 (PR #214), where the legacy spellings the parser reads first-for-compatibility become the sdk_only set instead. Real fields org_id/assessments_due/kill_switches_triggered added by this batch; by_use_case/by_status are deprecated fiction (never served on 9.x), spec-declared only by this fiction-era pin.",
+      "note": "deprecated-pending-removal: getaxonflow/axonflow-enterprise#3254 pin-advance batch (dataclass binding, #3262). sdk_only lists the LEGACY spellings the parser reads first-for-compatibility before falling back to the real v9.13.0 wire names (now spec-declared), here high/medium/low_materiality_count (real wire: high/medium/low_materiality), plus the deprecated fiction fields by_use_case/by_status (never served on 9.x, no wire equivalent). Legacy spellings and fiction fields burn down in the coordinated next major.",
       "sdk_only": [
-        "assessments_due",
-        "high_materiality",
-        "kill_switches_triggered",
-        "low_materiality",
-        "medium_materiality",
-        "org_id"
+        "by_status",
+        "by_use_case",
+        "high_materiality_count",
+        "low_materiality_count",
+        "medium_materiality_count"
       ],
       "spec_only": []
     },
-    "ResumePlanResponse": {
-      "note": "spec-bug-pending: #1745 \u2014 orchestrator-api.yaml ResumePlanResponse omits 7 fields returned on every WCP step approval/resume.",
-      "sdk_only": [
-        "approved",
-        "message",
-        "next_step",
-        "next_step_name",
-        "step_result",
-        "total_steps",
-        "workflow_id"
-      ],
-      "spec_only": []
-    },
-    "UpdateStaticPolicyRequest": {
-      "note": "acknowledged-sdk-superset: tracked in #1745. SDK accepts `category` on update; platform applies it but spec doesn't yet declare it.",
-      "sdk_only": [
-        "category"
-      ],
-      "spec_only": []
-    },
-    "UsageBreakdown": {
-      "note": "acknowledged-sdk-superset: tracked in #1745. SDK declares `period`/`period_end`/`period_start`; platform emits these on usage rollups but spec doesn't yet declare them.",
-      "sdk_only": [
-        "period",
-        "period_end",
-        "period_start"
-      ],
-      "spec_only": []
-    },
-    "UsageRecord": {
-      "note": "acknowledged-sdk-superset: tracked in #1745. SDK declares `timestamp`; platform emits it but spec doesn't yet declare it.",
-      "sdk_only": [
-        "timestamp"
-      ],
-      "spec_only": []
-    },
-    "UsageSummary": {
-      "note": "acknowledged-sdk-superset: tracked in #1745. SDK declares `period`; platform emits it but spec doesn't yet declare it.",
-      "sdk_only": [
-        "period"
-      ],
-      "spec_only": []
-    },
-    "WorkflowStepInfo": {
-      "note": "acknowledged-sdk-superset: tracked in #1745. SDK declares `approved_by`/`completed_at`/`decision_reason` for per-step audit context; platform emits these but spec doesn't yet declare them.",
-      "sdk_only": [
-        "approved_by",
-        "completed_at",
-        "decision_reason"
-      ],
-      "spec_only": []
+    "UnifiedStepStatus": {
+      "note": "acknowledged-spec-superset: the v9.13.0 spec declares rejected_at/rejected_by/tokens_in/tokens_out on UnifiedStepStatus; the SDK does not yet model them - additive server-side surface, no break. Newly registered by the v9.13.0 pin.",
+      "sdk_only": [],
+      "spec_only": [
+        "rejected_at",
+        "rejected_by",
+        "tokens_in",
+        "tokens_out"
+      ]
     }
   },
   "registered_models": [
     "AISystemRegistry",
     "AuditLogEntry",
     "AuditSearchRequest",
+    "AuditSearchResponse",
     "AuditToolCallRequest",
     "AuditToolCallResponse",
     "Budget",
@@ -479,7 +360,11 @@
     "CreateStaticPolicyRequest",
     "CreateWorkflowRequest",
     "CreateWorkflowResponse",
+    "DecideRequest",
+    "DecideResponse",
+    "DecisionCallerIdentity",
     "DecisionExplanation",
+    "DecisionTarget",
     "DynamicPolicy",
     "DynamicPolicyInfo",
     "DynamicPolicyMatch",
@@ -488,6 +373,12 @@
     "ExfiltrationCheckInfo",
     "ExplainPolicy",
     "ExplainRule",
+    "HITLApprovalRequest",
+    "HITLReviewInput",
+    "ImpactReportInput",
+    "ImpactReportRequest",
+    "ImpactReportResponse",
+    "ImpactReportResult",
     "KillSwitch",
     "LLMProviderListResponse",
     "ListWorkflowsResponse",
@@ -500,12 +391,16 @@
     "MediaGovernanceConfig",
     "MediaGovernanceStatus",
     "ModelPricing",
+    "ObligationFulfillment",
     "PaginationMeta",
     "PendingApproval",
     "PendingApprovalsResponse",
     "PlanResponse",
     "PlanVersionEntry",
     "PlanVersionsResponse",
+    "PolicyConflict",
+    "PolicyConflictRef",
+    "PolicyConflictResponse",
     "PolicyEvaluationInfo",
     "PolicyEvaluationResult",
     "PolicyMatch",
@@ -519,12 +414,16 @@
     "ResumePlanResponse",
     "RetryContext",
     "RollbackPlanResponse",
+    "SimulatePoliciesRequest",
+    "SimulatePoliciesResponse",
+    "SimulationDailyUsage",
     "StaticPolicy",
     "StepGateRequest",
     "StepGateResponse",
     "TimelineEntry",
     "TokenUsage",
     "ToolContext",
+    "UnifiedStepStatus",
     "UpdatePlanRequest",
     "UpdatePlanResponse",
     "UpdateStaticPolicyRequest",


### PR DESCRIPTION
## Summary

Re-lands the parked spec-pin refresh at community **v9.13.0** (the original v9.6.1 target is superseded). Refreshes the wire-shape contract baseline (`tests/fixtures/wire_shape_baseline.json`) via the repo's own regenerator (`scripts/refresh_wire_shape_baseline.py`) against a checkout of getaxonflow/axonflow tag `v9.13.0` `docs/api`.

**Spec pin:** `0bd92562` (v7.4.x era) -> `df027c788b60c18d044278c45aa4bce3a1ac8717` (tag **v9.13.0**).

**Merge order (this PR is STACKED, batch 2):** #223 is MERGED on main (`0fb80acd8`); this branch is now rebased onto main + #224 (`[#3254] pin-advance batch: masfeat/OJK additive extension`) and contains #224's commits. #224 merges FIRST. Without the batch, this pin would go red honestly on the audit models (the original 2026-08-03 stop) AND on the masfeat dataclass bindings #224 adds.

## Why the stop is resolved

The stop comments found that `AuditLogEntry`/`AuditSearchRequest` were built to spec fiction: the v9.6.1-era spec described fields (`blocked`/`success`/`risk_score`/`latency_ms`/`query_summary`/`policy_violations`/`metadata`, and the `request_type` search filter) that `platform/orchestrator/audit_logger.go` has never served on the 9.x line. The operator decision on getaxonflow/axonflow-enterprise#3254 sanctioned the **additive interim**: #223 adds the real wire fields (`policy_decision`/`policy_details`/`response_time_ms`, plus `action` on search) with deprecation notes on the fiction fields, and this PR **explicitly note-acknowledges** the remaining drift instead of silently baselining it:

- **`AuditLogEntry`** - `deprecated-pending-removal` entry naming #3254: sdk_only is exactly the seven deprecated fiction fields, burning down in the coordinated four-SDK next major per the #3254 operator decision. spec_only lists the 15 real wire fields not yet modeled (`query`/`query_hash`, `user_id`/`user_role`/`org_id`, `cost`, `error_message`, `correlation_id`/`session_id`/`plane`/`decision_id`, `redacted_fields`/`response_sample`/`compliance_flags`/`security_metrics`) - a read-side coverage gap, not a break.
- **`AuditSearchRequest`** - `deprecated-pending-removal` entry naming #3254: sdk_only `request_type` (server-side silent no-op, proven by the session-3254 live capture), removed in the next major; spec_only `session_id` (filter not yet modeled).

## Regen result vs the parked recipe

The stop comment predicted: 12 per-model drift entries, `MCPCheckInputRequest` drops out, 14 newly registered models. Actual regen (`--sha df027c788b60c18d044278c45aa4bce3a1ac8717`, via the #3262-extended regenerator): **15 per-model drift entries = the 12 the recipe predicted + 3 masfeat dataclass bindings (`RegistrySummary`/`KillSwitch`/`AISystemRegistry`) that #224 newly binds into the gate; `MCPCheckInputRequest` dropped (spec now declares `content_type` + `tool`); 93 registered models = the recipe's 90 + the 3 bound dataclasses; spec-bug-pending count 0.** At this pin the masfeat entries flip exactly as #224's notes predicted: sdk_only becomes the legacy spellings the parsers read first-for-compatibility (`high/medium/low_materiality_count`, `triggered_reason`, `business_owner`/`customer_impact`/`model_complexity`/`human_reliance`) plus the deprecated fiction fields (`by_use_case`/`by_status`, `technical_owner`), each noted deprecated-pending-removal naming #3254/#3262 and the next-major burn-down; spec_only lists the informational coverage gaps stated in #224 (`trigger_conditions`/`restore_reason`; `data_sources`/`model_type`/`version`/`deployment_date`/`last_assessment_date`/`next_assessment_due`/`updated_by`). `RegistrySummary` spec_only is EMPTY - the #224 parser reads `org_id`/`assessments_due`/`kill_switches_triggered`, verified by the regen itself.

Differences from the recipe's raw run, all explained by stacking on #223: `AuditLogEntry`'s sdk_only no longer contains `policy_decision`/`policy_details`/`response_time_ms` (now modeled AND spec-declared, so they match) and no longer contains `data_residency`/`transfer_basis` (the v9.13.0 spec declares them - the #1745 portion of that entry resolved); `AuditSearchRequest`'s sdk_only shrinks to `request_type` only (`action` now modeled and declared; `decision_id`/`offset`/`override_id`/`policy_name` are spec-declared since v9.6.1).

## Baseline entry changes (9 at v9.6.1 plan -> 12 at v9.13.0)

Resolved by the v9.13.0 spec (former notes dropped): `MCPCheckInputRequest` (`content_type`+`tool` declared), `MCPCheckOutputResponse.redaction_evaluated` (declared, as its v9.6.1 note predicted for the next pin bump), `DecisionExplanation.context`/`context_truncated` (declared), `AuditLogEntry.data_residency`/`transfer_basis` (declared).

Kept (notes carried/updated): `DecideResponse.error` (unchanged), `DynamicPolicyMatch`/`ExfiltrationCheckInfo`/`PolicyOverride`/`PolicyVersion` (deprecated-pending-removal 'Removed in v7' entries; `PolicyOverride` gains spec_only `organization_id`/`policy_type`/`tenant_id`/`updated_at`/`updated_by` - spec superset, no break), `MCPCheckOutputResponse` (re-noted: sdk_only now `policy_matches`/`redacted_message`, the Plugin Batch 1 v7.1.0-cycle fields the spec has not declared).

New spec-superset entries (each noted, additive server-side, no consumer break): `DecisionTarget.server` (#2904 two-field identity), `HITLApprovalRequest` (4 fields), `UnifiedStepStatus` (4 fields), plus the audit entries above.

**No true consumer break beyond the audit class surfaced** - every non-audit delta is either an SDK superset the platform accepts or a spec superset the SDK ignores on parse.

## Cross-train verification: the Go train's second stop (four non-audit read models)

The Go re-land (sdk-go#185) stopped a second time after its v9.13.0 regen surfaced the zero-out fiction class on four read models beyond the audit class: `RegistrySummary` (`high_materiality_count`/`by_status` vs the server's `high_materiality`, masfeat/types.go:431), `KillSwitch.triggered_reason` vs the server's `trigger_reason` (masfeat/types.go:288), `OJKAuditExportResponse.record_count`, and `AISystemRegistry.technical_owner`. Checked the Python SDK against SERVER SOURCE at tag v9.13.0 (`platform/orchestrator/masfeat/types.go` in a checkout of getaxonflow/axonflow @ `df027c788`), not the spec alone:

- **Python does NOT share the zero-out class on these types.** `axonflow/masfeat.py` parses each with an explicit real-wire fallback, pinned by `tests/test_masfeat.py`: `high_materiality_count = data.get("high_materiality_count") or data.get("high_materiality", 0)` (same for medium/low), `triggered_reason = data.get("triggered_reason") or data.get("trigger_reason")`, and `AISystemRegistry` maps `customer_impact`/`model_complexity`/`human_reliance` from the server's `risk_rating_impact`/`risk_rating_complexity`/`risk_rating_reliance` and `business_owner` from `owner_email`. Real server payloads populate these correctly today.
- **`OJKAuditExportResponse` is not modeled in Python at all** (zero OJK references under `axonflow/`).
- **Residual never-populated fields on those types, stated for the record** (fiction family, but "stays default", not "zeroes out real data"): `AISystemRegistry.technical_owner` (no such field anywhere in `platform/orchestrator/masfeat/` or `masfeat-api.yaml` at the tag; the SDK also SENDS it on register/update where the server does not read it) and `RegistrySummary.by_use_case`/`by_status` (no server equivalent; always `{}`). These are candidates for the #3254 next-major burn-down alongside the audit fiction fields.
- **Gate-visibility note:** the masfeat models are stdlib dataclasses, not pydantic BaseModels, so the wire-shape gate cannot bind them to `masfeat-api.yaml` schemas - they appear in neither `registered_models` nor `per_model_drift`. This regen therefore neither hides nor acknowledges anything about them; the dual-name parsing above is enforced by `tests/test_masfeat.py`, not by the contract gate. Worth folding into the #3254 next-major plan as a gate coverage gap.

## Conflict resolution (per the parked recipe)

Rebase conflict was confined to `tests/fixtures/wire_shape_baseline.json`; resolved by merging the note sets (main's #216/#218-era `AuditToolCallRequest`, `MCPCheckOutputRequest`, extended `MCPCheckInputRequest` notes taken as the base; this branch's v9.6.1-refresh note updates for `DecideResponse`/`DecisionExplanation` merged in) and then regenerating - the regenerator carries notes forward verbatim by model name.

## Validation

- `pytest tests/test_wire_shape.py -m wire_shape` with `AXONFLOW_OPENAPI_SPECS_DIR` pointing at a detached checkout of getaxonflow/axonflow @ `df027c788` (tag v9.13.0): **7/7 passed** (cross-spec divergence gate and rename-escape guard included).
- `pytest tests/test_refresh_wire_shape_baseline.py`: 4/4 passed (note-preservation and no-unannotated-drift gates).
- Full suite on the stacked branch: **1080 passed, 30 skipped** (coverage 82.88 percent). Wire-shape + baseline-format gates at this pin: **24 passed** (includes the #3262 dataclass binding test, its self-tests, and the batch-R3 ghost-probe/stale-allowance hard-fail checks - the stale check is a hard failure now and is green here because this baseline is regen-exact). Diff of this PR over #224's branch is **baseline-only** (`tests/fixtures/wire_shape_baseline.json`).

The `spec-pin-bump` label stays applied to authorize the `openapi_specs_sha` change per the wire-shape-contract CI guard.

Refs getaxonflow/axonflow-enterprise#3254, getaxonflow/axonflow-enterprise#2861.

## Regen integrity note (batch 2)

The first batch-2 regen attempt recorded a wrong-but-plausible `RegistrySummary` entry (the three #224 additions as spec_only): `python scripts/refresh_wire_shape_baseline.py` had `scripts/` at `sys.path[0]`, so `import axonflow` resolved through the venv's editable install - which pointed at a sibling checkout with the pre-fix parser. Caught by inspecting the regen output against the #224 parser, fixed in #224 (`09cd65f`): the script now pins its own repo root at `sys.path[0]`. The committed baseline here was regenerated AFTER that fix; `RegistrySummary.spec_only == []` is the observable proof the right parser was measured.
