### PR TITLE
docs: consolidate product demo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ A deployed AxonFlow platform (self-hosted or cloud) is required for end-to-end A
 
 Three short videos covering different angles of the platform:
 
-- **[Community Quickstart Demo (Code + Terminal, 2.5 min)](https://youtu.be/BSqU1z0xxCo)** — governed calls, PII block, Gateway Mode with LangChain/CrewAI, and MAP from YAML
-- **[Runtime Control Demo (Portal + Workflow, 2.5 min)](https://youtu.be/sRTv2uF0sxY)** — approvals, retry safety, execution state, and the audit viewer
-- **[Architecture Deep Dive (12 min)](https://youtu.be/Q2CZ1qnquhg)** — how the control plane works, policy enforcement flow, and multi-agent planning
+- **[Product demos: Platform + Fraud & Risk](https://getaxonflow.com/demo/?utm_source=github&utm_medium=readme&utm_campaign=product_demo&utm_content=axonflow-sdk-python)** - runtime enforcement, HITL approvals, audit evidence, cost visibility, and agentic payment controls
+- **[Community Quickstart walkthrough (2.5 min)](https://youtu.be/BSqU1z0xxCo)** - governed calls, PII blocking, Gateway Mode with LangChain/CrewAI, and MAP from YAML
+- **[Architecture deep dive (12 min)](https://youtu.be/Q2CZ1qnquhg)** - how the control plane works, policy enforcement flow, and multi-agent planning
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- send broad product-demo traffic to the canonical Platform and Fraud & Risk demo page
- retain the Community Quickstart as a specifically labeled technical walkthrough
- keep the architecture deep dive and any integration-specific walkthroughs as direct videos
- add repository-level attribution to the canonical demo link

## Verification
- git diff --check
- residual demo-link scan
- YouTube public metadata verification