### PR TITLE
docs(readme): correct the demo video count and runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ A deployed AxonFlow platform (self-hosted or cloud) is required for end-to-end A
 
 ### See AxonFlow in Action
 
-Three short videos covering different angles of the platform:
+Videos covering different angles of the platform:
 
 - **[Product demos: Platform + Fraud & Risk](https://getaxonflow.com/demo/?utm_source=github&utm_medium=readme&utm_campaign=product_demo&utm_content=axonflow-sdk-python)** - runtime enforcement, HITL approvals, audit evidence, cost visibility, and agentic payment controls
-- **[Community Quickstart walkthrough (2.5 min)](https://youtu.be/BSqU1z0xxCo)** - governed calls, PII blocking, Gateway Mode with LangChain/CrewAI, and MAP from YAML
+- **[Community Quickstart walkthrough (2 min)](https://youtu.be/BSqU1z0xxCo)** - governed calls, PII blocking, Gateway Mode with LangChain/CrewAI, and MAP from YAML
 - **[Architecture deep dive (12 min)](https://youtu.be/Q2CZ1qnquhg)** - how the control plane works, policy enforcement flow, and multi-agent planning
 
 ## Installation


### PR DESCRIPTION
Two factual corrections to the demo video list on this README. Prose only, no code, no behaviour change.

## 1. The video count was wrong

A recent link sweep replaced the first bullet of the list with a link to <https://getaxonflow.com/demo/>, a page that carries **two** videos (Platform, and the Fraud & Risk Add-on). The introductory count was left untouched, so the sentence under-counted the list it introduces.

Fixed by dropping the quantifier entirely rather than re-deriving it. Re-deriving would only rot again the next time that page gains or loses a video, and the count is genuinely ambiguous now that one bullet points at a multi-video page.

```diff
-Three short videos covering different angles of the platform:
+Videos covering different angles of the platform:
```

"short" is dropped along with it: the same list carries a **12 minute** architecture deep dive, which the word does not describe.

## 2. The Community Quickstart runtime was never right

The video is **2:05**, not 2.5 min.

```diff
-- **[Community Quickstart walkthrough (2.5 min)](https://youtu.be/BSqU1z0xxCo)** - governed calls, ...
+- **[Community Quickstart walkthrough (2 min)](https://youtu.be/BSqU1z0xxCo)** - governed calls, ...
```

## Runtime verification

Fetched the YouTube watch page directly rather than taking the figure on trust:

```
$ curl -s "https://www.youtube.com/watch?v=BSqU1z0xxCo" | grep -o '.\{140\}"lengthSeconds":"[0-9]*"'
tAudioTrackIndex":0}},"videoDetails":{"videoId":"BSqU1z0xxCo","title":"AxonFlow - Execution
Control for Production LLM and Agent Workflows","lengthSeconds":"125"

$ curl -s "https://www.youtube.com/watch?v=BSqU1z0xxCo" | grep -o '"approxDurationMs":"[0-9]*"' | sort -u
"approxDurationMs":"125440"
"approxDurationMs":"125461"
"approxDurationMs":"125480"
```

**125 seconds = 2:05.** Two independent fields in the player response agree: `videoDetails.lengthSeconds` is `125`, and the per stream `approxDurationMs` values are all ~125.4 s. The page's own chapter list ends at `01:46 - Why AxonFlow (wrap-up)`, which is consistent with a 2:05 runtime.

(The `playerMicroformatRenderer` reports `126`; that field ceiling-rounds. `videoDetails` is the authoritative figure.)

## Not changed

The Banking workflow video (<https://youtu.be/sRTv2uF0sxY>) genuinely is 2.5 min: its `lengthSeconds` is `151`, i.e. 2:31. It is correctly labelled wherever it appears. It is not referenced in this README, but noting it so the `2.5 min` string is not swept globally by a later pass.

## Scope

This is one of ten sibling PRs applying the same two corrections across the repos whose READMEs carry this list. Each is an ordinary PR against `main`; no sync workflow was run.
